### PR TITLE
Bug fixes found by ebpf-for-windows tests

### DIFF
--- a/inc/usersim/ke.h
+++ b/inc/usersim/ke.h
@@ -197,6 +197,12 @@ extern "C"
 
     void KeSetTargetProcessorDpc(_Inout_ PRKDPC dpc, CCHAR number);
 
+    void
+    usersim_initialize_dpcs();
+
+    void
+    usersim_clean_up_dpcs();
+
 #pragma endregion dpcs
 #pragma region timers
 
@@ -247,6 +253,12 @@ extern "C"
 #if defined(__cplusplus)
 }
 #endif
+
+typedef enum
+{
+    IRQL_NOT_LESS_OR_EQUAL = 0x0A,
+    TIMER_OR_DPC_INVALID = 0xC7,
+} usersim_bug_check_code_t;
 
 // The bug check functions below throw C++ exceptions so tests can catch them to verify error behavior.
 void

--- a/src/platform_user.cpp
+++ b/src/platform_user.cpp
@@ -193,8 +193,6 @@ _get_environment_variable_as_size_t(const std::string& name)
     }
 }
 
-void usersim_initialize_dpcs();
-
 _Must_inspect_result_ usersim_result_t
 usersim_platform_initiate()
 {
@@ -248,14 +246,14 @@ usersim_platform_terminate()
 {
     ExWaitForRundownProtectionRelease(&_usersim_platform_preemptible_work_items_rundown);
 
+    usersim_free_semaphores();
+    usersim_free_threadpool_timers();
+    usersim_clean_up_dpcs();
     _clean_up_thread_pool();
     if (_usersim_leak_detector_ptr) {
         _usersim_leak_detector_ptr->dump_leaks();
         _usersim_leak_detector_ptr.reset();
     }
-
-    usersim_free_semaphores();
-    usersim_free_threadpool_timers();
 
     int32_t count = InterlockedDecrement((volatile long*)&_usersim_platform_initiate_count);
     if (count < 0) {


### PR DESCRIPTION
* Allow `KeFlushQueuedDpcs()` to be called multiple times
* Allow `KeCancelTimer()` to be called at dispatch level
* Run leak detection after, not before, freeing usersim platform state
* Handle race conditions with `KeInsertQueueDpc()`
* Add tests for the above