### PR TITLE
Make DISPATCH_LEVEL code run at THREAD_PRIORITY_TIME_CRITICAL

### DIFF
--- a/inc/usersim/ke.h
+++ b/inc/usersim/ke.h
@@ -50,7 +50,7 @@ extern "C"
 #undef DISPATCH_LEVEL
 #define PASSIVE_LEVEL THREAD_PRIORITY_NORMAL   // Passive release level.
 #define APC_LEVEL THREAD_PRIORITY_ABOVE_NORMAL // APC interrupt level.
-#define DISPATCH_LEVEL THREAD_PRIORITY_HIGHEST // Dispatcher level.
+#define DISPATCH_LEVEL THREAD_PRIORITY_TIME_CRITICAL // Dispatcher level.
 
     KIRQL
     KeGetCurrentIrql();


### PR DESCRIPTION
DPCs already did, but using KeRaiseIrql with DISPATCH_LEVEL incorrectly used THREAD_PRIORITY_HIGHEST

Fixes #42