### PR TITLE
Serialize dispatch level code on each processor

### DIFF
--- a/inc/usersim/ke.h
+++ b/inc/usersim/ke.h
@@ -54,8 +54,8 @@ extern "C"
 #undef PASSIVE_LEVEL
 #undef APC_LEVEL
 #undef DISPATCH_LEVEL
-#define PASSIVE_LEVEL THREAD_PRIORITY_NORMAL   // Passive release level.
-#define APC_LEVEL THREAD_PRIORITY_ABOVE_NORMAL // APC interrupt level.
+#define PASSIVE_LEVEL THREAD_PRIORITY_NORMAL         // Passive release level.
+#define APC_LEVEL THREAD_PRIORITY_ABOVE_NORMAL       // APC interrupt level.
 #define DISPATCH_LEVEL THREAD_PRIORITY_TIME_CRITICAL // Dispatcher level.
 
     USERSIM_API
@@ -76,6 +76,12 @@ extern "C"
 
     USERSIM_API
     _IRQL_requires_min_(DISPATCH_LEVEL) NTKERNELAPI LOGICAL KeShouldYieldProcessor(VOID);
+
+    usersim_result_t
+    usersim_initialize_irql();
+
+    void
+    usersim_clean_up_irql();
 
 #pragma endregion irqls
 
@@ -138,6 +144,9 @@ extern "C"
     PKTHREAD
     NTAPI
     KeGetCurrentThread(VOID);
+
+    void
+    usersim_get_current_thread_group_affinity(_Out_ GROUP_AFFINITY* Affinity);
 
 #pragma endregion threads
 
@@ -206,7 +215,7 @@ extern "C"
     typedef KDPC* PKDPC;
     typedef KDPC* PRKDPC;
 
-    typedef void (KDEFERRED_ROUTINE)(
+    typedef void(KDEFERRED_ROUTINE)(
         _In_ KDPC* dpc,
         _In_opt_ void* deferred_context,
         _In_opt_ void* system_argument1,
@@ -225,20 +234,27 @@ extern "C"
 
     USERSIM_API
     void
-    KeInitializeDpc(_Out_ __drv_aliasesMem PRKDPC dpc, _In_ PKDEFERRED_ROUTINE deferred_routine, _In_opt_ __drv_aliasesMem PVOID deferred_context);
+    KeInitializeDpc(
+        _Out_ __drv_aliasesMem PRKDPC dpc,
+        _In_ PKDEFERRED_ROUTINE deferred_routine,
+        _In_opt_ __drv_aliasesMem PVOID deferred_context);
 
     USERSIM_API
-    BOOLEAN KeInsertQueueDpc(_Inout_ PRKDPC dpc, _In_opt_ PVOID system_argument1, _In_opt_ __drv_aliasesMem PVOID system_argument2);
+    BOOLEAN
+    KeInsertQueueDpc(
+        _Inout_ PRKDPC dpc, _In_opt_ PVOID system_argument1, _In_opt_ __drv_aliasesMem PVOID system_argument2);
 
     USERSIM_API
-    BOOLEAN KeRemoveQueueDpc(_Inout_ PRKDPC dpc);
+    BOOLEAN
+    KeRemoveQueueDpc(_Inout_ PRKDPC dpc);
 
     USERSIM_API
     void
     KeFlushQueuedDpcs();
 
     USERSIM_API
-    void KeSetTargetProcessorDpc(_Inout_ PRKDPC dpc, CCHAR number);
+    void
+    KeSetTargetProcessorDpc(_Inout_ PRKDPC dpc, CCHAR number);
 
     void
     usersim_initialize_dpcs();
@@ -272,10 +288,12 @@ extern "C"
 
     USERSIM_API
     BOOLEAN
-    KeSetCoalescableTimer(_Inout_ PKTIMER timer, LARGE_INTEGER due_time, ULONG period, ULONG tolerable_delay, _In_opt_ PKDPC dpc);
+    KeSetCoalescableTimer(
+        _Inout_ PKTIMER timer, LARGE_INTEGER due_time, ULONG period, ULONG tolerable_delay, _In_opt_ PKDPC dpc);
 
     USERSIM_API
-    BOOLEAN KeCancelTimer(_Inout_ PKTIMER timer);
+    BOOLEAN
+    KeCancelTimer(_Inout_ PKTIMER timer);
 
     USERSIM_API
     BOOLEAN
@@ -287,7 +305,8 @@ extern "C"
 #pragma endregion timers
 
     USERSIM_API
-    LARGE_INTEGER KeQueryPerformanceCounter(_Out_opt_ PLARGE_INTEGER performance_frequency);
+    LARGE_INTEGER
+    KeQueryPerformanceCounter(_Out_opt_ PLARGE_INTEGER performance_frequency);
 
     USERSIM_API
     void

--- a/src/platform_user.cpp
+++ b/src/platform_user.cpp
@@ -1,16 +1,16 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
+#include "../inc/TraceLoggingProvider.h"
 #include "fault_injection.h"
 #include "leak_detector.h"
 #include "symbol_decoder.h"
 #include "tracelog.h"
-#include "utilities.h"
 #include "usersim/ex.h"
 #include "usersim/ke.h"
 #include "usersim/mm.h"
+#include "utilities.h"
 
-#include "../inc/TraceLoggingProvider.h"
 #include <functional>
 #include <intsafe.h>
 #include <map>
@@ -196,6 +196,8 @@ _get_environment_variable_as_size_t(const std::string& name)
 _Must_inspect_result_ usersim_result_t
 usersim_platform_initiate()
 {
+    usersim_result_t result;
+
     int32_t count = InterlockedIncrement((volatile long*)&_usersim_platform_initiate_count);
     if (count > 1) {
         // Usersim library already initialized, return.
@@ -223,6 +225,11 @@ usersim_platform_initiate()
             _usersim_leak_detector_ptr = std::make_unique<usersim_leak_detector_t>();
         }
 
+        result = usersim_initialize_irql();
+        if (result != STATUS_SUCCESS) {
+            goto Exit;
+        }
+
         usersim_initialize_dpcs();
 
         // Compute the starting index of each processor group.
@@ -238,7 +245,13 @@ usersim_platform_initiate()
         return STATUS_NO_MEMORY;
     }
 
-    usersim_result_t result = _initialize_thread_pool();
+    result = _initialize_thread_pool();
+    if (result != STATUS_SUCCESS) {
+        goto Exit;
+    }
+
+Exit:
+
     if (result != STATUS_SUCCESS) {
         // Clean up since usersim_platform_terminate() will not be called by the caller.
         usersim_platform_terminate();
@@ -254,6 +267,7 @@ usersim_platform_terminate()
     usersim_free_semaphores();
     usersim_free_threadpool_timers();
     usersim_clean_up_dpcs();
+    usersim_clean_up_irql();
     _clean_up_thread_pool();
     if (_usersim_leak_detector_ptr) {
         _usersim_leak_detector_ptr->dump_leaks();
@@ -428,7 +442,8 @@ usersim_allocate_ring_buffer_memory(size_t length)
         return nullptr;
     }
 
-    usersim_ring_descriptor_t* descriptor = (usersim_ring_descriptor_t*)usersim_allocate(sizeof(usersim_ring_descriptor_t));
+    usersim_ring_descriptor_t* descriptor =
+        (usersim_ring_descriptor_t*)usersim_allocate(sizeof(usersim_ring_descriptor_t));
     if (!descriptor) {
         goto Exit;
     }
@@ -615,26 +630,6 @@ usersim_query_time_since_boot(bool include_suspended_time)
     }
 
     return interrupt_time;
-}
-
-_Must_inspect_result_ usersim_result_t
-usersim_set_current_thread_affinity(uintptr_t new_thread_affinity_mask, _Out_ uintptr_t* old_thread_affinity_mask)
-{
-    uintptr_t old_mask = SetThreadAffinityMask(GetCurrentThread(), new_thread_affinity_mask);
-    if (old_mask == 0) {
-        unsigned long error = GetLastError();
-        usersim_assert(error != ERROR_SUCCESS);
-        return STATUS_NOT_SUPPORTED;
-    } else {
-        *old_thread_affinity_mask = old_mask;
-        return STATUS_SUCCESS;
-    }
-}
-
-void
-usersim_restore_current_thread_affinity(uintptr_t old_thread_affinity_mask)
-{
-    SetThreadAffinityMask(GetCurrentThread(), old_thread_affinity_mask);
 }
 
 _Ret_range_(>, 0) uint32_t usersim_get_cpu_count() { return _usersim_platform_maximum_processor_count; }
@@ -992,19 +987,19 @@ usersim_platform_detach_process(_In_ usersim_process_state_t* state)
     UNREFERENCED_PARAMETER(state);
 }
 
-#define HANDLE_VARIABLE_TYPE(type, fmt) \
-     { \
-        int count = va_arg(valist, int); \
-        i++; \
-        if (count > 0) { \
-            type value = va_arg(valist, type); \
-            printf("," fmt, value); \
-        } \
-        for (int j = 1; j < count; j++) { \
+#define HANDLE_VARIABLE_TYPE(type, fmt)                    \
+    {                                                      \
+        int count = va_arg(valist, int);                   \
+        i++;                                               \
+        if (count > 0) {                                   \
+            type value = va_arg(valist, type);             \
+            printf("," fmt, value);                        \
+        }                                                  \
+        for (int j = 1; j < count; j++) {                  \
             const char* str = va_arg(valist, const char*); \
-            printf(",\"%s\"", str); \
-        } \
-        i += count; \
+            printf(",\"%s\"", str);                        \
+        }                                                  \
+        i += count;                                        \
     }
 
 static bool _usersim_trace_logging_enabled = false;
@@ -1036,7 +1031,7 @@ usersim_trace_logging_write(_In_ const TraceLoggingHProvider hProvider, _In_z_ c
     if (!_usersim_trace_logging_enabled) {
         return;
     }
-    
+
     printf("{%s", eventName);
 
     va_list valist;
@@ -1059,8 +1054,7 @@ usersim_trace_logging_write(_In_ const TraceLoggingHProvider hProvider, _In_z_ c
             opcode = va_arg(valist, int);
             i++;
             break;
-        case _tlgCountedUtf8String:
-            {
+        case _tlgCountedUtf8String: {
             const char* value = va_arg(valist, const char*);
             i++;
             int size = va_arg(valist, int);
@@ -1076,8 +1070,8 @@ usersim_trace_logging_write(_In_ const TraceLoggingHProvider hProvider, _In_z_ c
             }
             i += count;
             break;
-            }
-        case _tlgPsz: 
+        }
+        case _tlgPsz:
             HANDLE_VARIABLE_TYPE(const char*, "\"%s\"");
             break;
         case _tlgPwsz:
@@ -1122,8 +1116,7 @@ usersim_trace_logging_write(_In_ const TraceLoggingHProvider hProvider, _In_z_ c
             i += count;
             break;
         }
-        case _tlgIPv4Address:
-        {
+        case _tlgIPv4Address: {
             int count = va_arg(valist, int);
             i++;
             if (count > 0) {
@@ -1139,8 +1132,7 @@ usersim_trace_logging_write(_In_ const TraceLoggingHProvider hProvider, _In_z_ c
             i += count;
             break;
         }
-        case _tlgIPv6Address:
-        {
+        case _tlgIPv6Address: {
             int count = va_arg(valist, int);
             i++;
             if (count > 0) {

--- a/src/platform_user.cpp
+++ b/src/platform_user.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
-#include "../inc/TraceLoggingProvider.h"
 #include "fault_injection.h"
 #include "leak_detector.h"
 #include "symbol_decoder.h"
@@ -11,6 +10,7 @@
 #include "usersim/mm.h"
 #include "utilities.h"
 
+#include "../inc/TraceLoggingProvider.h"
 #include <functional>
 #include <intsafe.h>
 #include <map>


### PR DESCRIPTION
Ensure the following:

1. Dispatch level code cannot migrate across processors.
2. Dispatch level code cannot be preempted by code running at lower IRQLs on the same processor.
3. Dispatch level code cannot preempt other dispatch level code on the same processor.

This requires the following:

1. Emulate kernel thread affinity rather than directly setting and getting the Win32 thread affinity.
2. Set the process to be in the realtime thread priority class. This ensures thread priority orders are strictly honored.
3. Set the Win32 thread affinity to a single processor (within the thread's emulated affinity group) whenever IRQL is raised to dispatch level.
4. Acquire a per-processor mutex whenever IRQL is raised to dispatch level.

A new test case is added and verified.

This PR does not address the following issue(s):

1. Kernel timers implemented with the Win32 threadpool do not preempt dispatch level code. The threadpool documentation does not specify how TP_CALLBACK_PRIORITY_HIGH relates to Win32 thread priorities, but kernel timers should fire at an IRQL greater than dispatch level, queue a DPC at greater than dispatch IRQL, and run their DPCs at dispatch level. I suspect we'll need to rewrite the timer module to use our own threads.

Resolves #42 
