### PR TITLE
Fix thread mutex destructor assert

### DIFF
--- a/src/ke.cpp
+++ b/src/ke.cpp
@@ -411,6 +411,14 @@ class _usersim_emulated_dpc
         terminate = true;
         condition_variable.notify_all();
         thread.join();
+
+        // On process termination, the system may have killed the thread before
+        // it could release the mutex. If that happens, the kernel will have
+        // released the mutex, but the user-mode class won't know that yet.
+        // Work around this issue by trying to take the mutex here (forcing
+        // user-mode to be reconciled with the actual kernel-mode state), to
+        // avoid the mutex destructor asserting due to destruction without releasing.
+        std::unique_lock<std::mutex> l(mutex);
     }
 
     /**

--- a/src/ke.cpp
+++ b/src/ke.cpp
@@ -372,6 +372,7 @@ class _usersim_emulated_dpc
             SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
             for (;;) {
                 if (terminate) {
+                    KeLowerIrql(old_irql);
                     return;
                 }
 
@@ -407,7 +408,6 @@ class _usersim_emulated_dpc
      */
     ~_usersim_emulated_dpc()
     {
-        KeLowerIrql(old_irql);
         terminate = true;
         condition_variable.notify_all();
         thread.join();


### PR DESCRIPTION
Thanks to Alan for helping track down what was going on.  Upon process termination, all threads are killed before DllMain is called.  But the DPC design uses persistent threads that each have their own mutex.  If a thread is killed while holding the mutex, this would result in the mutex destructor hitting an assert.  Among other effects, this hung the build because that happens when running export_program_info.exe and bpf2c.exe.

Add a workaround for this issue.