### PR TITLE
Fix race that causes missed wake

### DIFF
--- a/src/ke.cpp
+++ b/src/ke.cpp
@@ -498,7 +498,12 @@ class _usersim_emulated_dpc
     ~_usersim_emulated_dpc()
     {
         SetThreadPriority(GetCurrentThread(), PASSIVE_LEVEL);
-        terminate = true;
+        // Set the flag to terminate the thread while holding the lock, to make
+        // sure the thread is not in the middle of a wait.
+        {
+            std::unique_lock<std::mutex> l(mutex);
+            terminate = true;
+        }
         condition_variable.notify_all();
         thread.join();
 


### PR DESCRIPTION
Resolves: #60 

The APIs std::condition_variable::notify_all and std::condition_variable::wait require conditions on which the wait is being performed are only modified while holding the lock that wait acquires and releases as part of it's conditional wait. 

Failure to do this can result in missed wake notifications, which shows up as an infinite hang during fault injection tests, with the following stack:
```
 # Child-SP          RetAddr               Call Site
00 000000e1`ae16e618 00007ff9`178dd77e     ntdll!ZwWaitForSingleObject+0x14
01 000000e1`ae16e620 00007ff8`efb92e5f     KERNELBASE!WaitForSingleObjectEx+0x8e
02 000000e1`ae16e6c0 00007ff6`cce490e7     msvcp140!Thrd_join+0x1f
03 000000e1`ae16e6f0 00007ff6`ccf5d73f     unit_tests!std::thread::join+0x47 [C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\include\thread @ 128] 
04 (Inline Function) --------`--------     unit_tests!_usersim_emulated_dpc::{dtor}+0x52 [D:\a\ebpf-for-windows\ebpf-for-windows\external\usersim\src\ke.cpp @ 413] 
05 (Inline Function) --------`--------     unit_tests!std::_Destroy_in_place+0x52 [C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\include\xmemory @ 298] 
06 000000e1`ae16e730 00007ff6`ccf5ced0     unit_tests!std::_Ref_count_obj2<_usersim_emulated_dpc>::_Destroy+0x5f [C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\include\memory @ 2009] 
07 (Inline Function) --------`--------     unit_tests!std::_Ref_count_base::_Decref+0x17 [C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\include\memory @ 1070] 
08 (Inline Function) --------`--------     unit_tests!std::_Ptr_base<_usersim_emulated_dpc>::_Decref+0x20 [C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\include\memory @ 1295] 
09 (Inline Function) --------`--------     unit_tests!std::shared_ptr<_usersim_emulated_dpc>::{dtor}+0x20 [C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\include\memory @ 1579] 
0a (Inline Function) --------`--------     unit_tests!std::destroy_at+0x20 [C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\include\xmemory @ 311] 
0b (Inline Function) --------`--------     unit_tests!std::_Default_allocator_traits<std::allocator<std::shared_ptr<_usersim_emulated_dpc> > >::destroy+0x20 [C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\include\xmemory @ 687] 
0c 000000e1`ae16e760 00007ff6`ccf5ffcf     unit_tests!std::_Destroy_range<std::allocator<std::shared_ptr<_usersim_emulated_dpc> > >+0x40 [C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\include\xmemory @ 947] 
0d (Inline Function) --------`--------     unit_tests!std::vector<std::shared_ptr<_usersim_emulated_dpc>,std::allocator<std::shared_ptr<_usersim_emulated_dpc> > >::_Resize+0x25 [C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\include\vector @ 1624] 
0e (Inline Function) --------`--------     unit_tests!std::vector<std::shared_ptr<_usersim_emulated_dpc>,std::allocator<std::shared_ptr<_usersim_emulated_dpc> > >::resize+0x25 [C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\include\vector @ 1655] 
0f (Inline Function) --------`--------     unit_tests!usersim_clean_up_dpcs+0x25 [D:\a\ebpf-for-windows\ebpf-for-windows\external\usersim\src\ke.cpp @ 535] 
10 000000e1`ae16e790 00007ff6`ccf5fe7f     unit_tests!usersim_platform_terminate+0x11f [D:\a\ebpf-for-windows\ebpf-for-windows\external\usersim\src\platform_user.cpp @ 256] 
11 000000e1`ae16e7c0 00007ff6`ccfb3175     unit_tests!usersim_platform_initiate+0x52f [D:\a\ebpf-for-windows\ebpf-for-windows\external\usersim\src\platform_user.cpp @ 246] 
12 (Inline Function) --------`--------     unit_tests!ebpf_platform_initiate+0x16 [D:\a\ebpf-for-windows\ebpf-for-windows\libs\platform\user\ebpf_platform_user.cpp @ 33] 
13 000000e1`ae16e870 00007ff6`cce23de6     unit_tests!ebpf_core_initiate+0x25 [D:\a\ebpf-for-windows\ebpf-for-windows\libs\execution_context\ebpf_core.c @ 179] 
14 000000e1`ae16e8f0 00007ff6`cce13d23     unit_tests!_ebpf_core_initializer::initialize+0xb6 [D:\a\ebpf-for-windows\ebpf-for-windows\libs\execution_context\unit\execution_context_unit_test.cpp @ 97] 
15 000000e1`ae16e9f0 00007ff6`ccf35835     unit_tests!CATCH2_INTERNAL_TEST_42+0x43 [D:\a\ebpf-for-windows\ebpf-for-windows\libs\execution_context\unit\execution_context_unit_test.cpp @ 1450] 
16 000000e1`ae16ee50 00007ff6`ccf35f6d     unit_tests!Catch::RunContext::invokeActiveTestCase+0x45
17 000000e1`ae16ee80 00007ff6`ccf36548     unit_tests!Catch::RunContext::runCurrentTest+0x33d
18 000000e1`ae16f0a0 00007ff6`ccffbc25     unit_tests!Catch::RunContext::runTest+0x398
19 000000e1`ae16f400 00007ff6`ccffc64d     unit_tests!Catch::Clara::Detail::BasicResult<Catch::Clara::Detail::ParseState>::enforceOk+0xa5
1a 000000e1`ae16f490 00007ff6`ccff76ea     unit_tests!Catch::Session::runInternal+0x24d
1b 000000e1`ae16f770 00007ff6`ccdf7a78     unit_tests!main+0x9a
1c (Inline Function) --------`--------     unit_tests!invoke_main+0x22 [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl @ 78] 
1d 000000e1`ae16f930 00007ff9`185d4de0     unit_tests!__scrt_common_main_seh+0x10c [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl @ 288] 
1e 000000e1`ae16f970 00007ff9`1a1bec4b     kernel32!BaseThreadInitThunk+0x10
1f 000000e1`ae16f9a0 00000000`00000000     ntdll!RtlUserThreadStart+0x2b
```