### PR TITLE
Add RtlAssert()

### DIFF
--- a/inc/usersim/rtl.h
+++ b/inc/usersim/rtl.h
@@ -106,9 +106,27 @@ extern "C"
         _In_ PCCH utf8_string_source,
         _In_ ULONG utf8_string_byte_count);
 
+    USERSIM_API
+    __analysis_noreturn VOID NTAPI
+    RtlAssert(
+        _In_ PVOID void_failed_assertion,
+        _In_ PVOID void_file_name,
+        _In_ ULONG line_number,
+        _In_opt_ PSTR mutable_message);
+
 // Include Rtl* implementations from ntdll.lib.
 #pragma comment(lib, "ntdll.lib")
 
 #if defined(__cplusplus)
 }
+
+// The functions below throw C++ exceptions so tests can catch them to verify error behavior.
+
+USERSIM_API __analysis_noreturn void
+RtlAssertCPP(
+    _In_ PVOID void_failed_assertion,
+    _In_ PVOID void_file_name,
+    _In_ ULONG line_number,
+    _In_opt_ PSTR mutable_message);
+
 #endif

--- a/src/rtl.cpp
+++ b/src/rtl.cpp
@@ -4,6 +4,7 @@
 #include "fault_injection.h"
 #include "platform.h"
 #include "kernel_um.h"
+#include "usersim/ke.h"
 #include "usersim/rtl.h"
 #include "utilities.h"
 #include <intsafe.h>
@@ -118,4 +119,27 @@ RtlSizeTSub(
     size_t minuend, size_t subtrahend, _Out_ _Deref_out_range_(==, minuend - subtrahend) size_t* result)
 {
     return SUCCEEDED(SizeTSub(minuend, subtrahend, result)) ? STATUS_SUCCESS : STATUS_INTEGER_OVERFLOW;
+}
+
+__analysis_noreturn VOID NTAPI
+RtlAssertCPP(
+    _In_ PVOID void_failed_assertion,
+    _In_ PVOID void_file_name,
+    _In_ ULONG line_number,
+    _In_opt_ PSTR mutable_message)
+{
+    UNREFERENCED_PARAMETER(void_failed_assertion);
+    UNREFERENCED_PARAMETER(void_file_name);
+    UNREFERENCED_PARAMETER(mutable_message);
+    KeBugCheckEx(0, line_number, NULL, NULL, NULL);
+}
+
+__analysis_noreturn VOID NTAPI
+RtlAssert(
+    _In_ PVOID void_failed_assertion,
+    _In_ PVOID void_file_name,
+    _In_ ULONG line_number,
+    _In_opt_ PSTR mutable_message)
+{
+    RtlAssertCPP(void_failed_assertion, void_file_name, line_number, mutable_message);
 }

--- a/tests/rtl_test.cpp
+++ b/tests/rtl_test.cpp
@@ -16,3 +16,17 @@ TEST_CASE("RtlULongAdd", "[rtl]")
 
     REQUIRE(RtlULongAdd(ULONG_MAX, 1, &result) == STATUS_INTEGER_OVERFLOW);
 }
+
+TEST_CASE("RtlAssert", "[rtl]")
+{
+    try {
+        RtlAssertCPP((PVOID) "0 == 1", (PVOID) "filename.c", 17, nullptr);
+        REQUIRE(FALSE);
+    } catch (std::exception e) {
+        REQUIRE(
+            strcmp(
+                e.what(),
+                "*** STOP 0x00000000 (0x0000000000000011,0x0000000000000000,0x0000000000000000,0x0000000000000000)") ==
+            0);
+    }
+}


### PR DESCRIPTION
Add support for RtlAssert.
Initial implementation is a simple wrapper around KeBugCheckEx.