### PR TITLE
Add probe APIs and tests

### DIFF
--- a/inc/usersim/ex.h
+++ b/inc/usersim/ex.h
@@ -178,6 +178,12 @@ extern "C"
     USERSIM_API
     _IRQL_requires_max_(PASSIVE_LEVEL) NTKERNELAPI NTSTATUS ExUuidCreate(_Out_ UUID* uuid);
 
+    USERSIM_API void
+    ExRaiseAccessViolation();
+
+    USERSIM_API void
+    ExRaiseDatatypeMisalignment();
+
 #if defined(__cplusplus)
 }
 
@@ -194,5 +200,11 @@ ExAllocatePoolWithTagCPP(
 
 USERSIM_API _Ret_maybenull_ void*
 ExAllocatePoolUninitializedCPP(_In_ POOL_TYPE pool_type, _In_ size_t number_of_bytes, _In_ unsigned long tag);
+
+USERSIM_API void
+ExRaiseAccessViolationCPP();
+
+USERSIM_API void
+ExRaiseDatatypeMisalignmentCPP();
 
 #endif

--- a/inc/usersim/ke.h
+++ b/inc/usersim/ke.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include "..\src\platform.h"
+#include <string>
 
 #if defined(__cplusplus)
 extern "C"
@@ -335,5 +336,8 @@ KeBugCheckExCPP(
     ULONG_PTR bug_check_parameter2,
     ULONG_PTR bug_check_parameter3,
     ULONG_PTR bug_check_parameter4);
+
+void
+usersim_throw_exception(_In_ std::string message);
 
 #endif

--- a/inc/usersim/mm.h
+++ b/inc/usersim/mm.h
@@ -120,12 +120,27 @@ extern "C"
     NTSTATUS
     MmProtectMdlSystemAddress(_In_ MDL* memory_descriptor_list, ULONG new_protect);
 
+    USERSIM_API void
+    ProbeForRead(_In_ const volatile void* address, SIZE_T length, ULONG alignment);
+
+    USERSIM_API void
+    ProbeForWrite(_Inout_ volatile void* address, SIZE_T length, ULONG alignment);
+
 #if defined(__cplusplus)
 }
 
 // The functions below throw C++ exceptions so tests can catch them to verify error behavior.
 
+USERSIM_API
 void
 MmUnmapLockedPagesCPP(_In_ void* base_address, _In_ MDL* memory_descriptor_list);
+
+USERSIM_API
+void
+ProbeForReadCPP(_In_ const volatile void* address, SIZE_T length, ULONG alignment);
+
+USERSIM_API
+void
+ProbeForWriteCPP(_Inout_ volatile void* address, SIZE_T length, ULONG alignment);
 
 #endif

--- a/src/ex.cpp
+++ b/src/ex.cpp
@@ -10,6 +10,7 @@
 #include <condition_variable>
 #include <map>
 #include <mutex>
+#include <sstream>
 #include <tuple>
 
 // Ex* functions.
@@ -374,4 +375,38 @@ _IRQL_requires_max_(PASSIVE_LEVEL) NTKERNELAPI NTSTATUS ExUuidCreate(_Out_ UUID*
     } else {
         return STATUS_NOT_SUPPORTED;
     }
+}
+
+void
+ExRaiseAccessViolationCPP()
+{
+    // This should really use RaiseException(STATUS_ACCESS_VIOLATION, 0, 0, 0)
+    // but SEH doesn't seem to play well with Catch2 so for now we use C++
+    // exceptions.
+    std::ostringstream ss;
+    ss << "Exception: " << STATUS_ACCESS_VIOLATION << "\n";
+    usersim_throw_exception(ss.str());
+}
+
+void
+ExRaiseAccessViolation()
+{
+    ExRaiseAccessViolationCPP();
+}
+
+void
+ExRaiseDatatypeMisalignmentCPP()
+{
+    // This should really use RaiseException(STATUS_DATATYPE_MISALIGNMENT, 0, 0, 0)
+    // but SEH doesn't seem to play well with Catch2 so for now we use C++
+    // exceptions.
+    std::ostringstream ss;
+    ss << "Exception: " << STATUS_DATATYPE_MISALIGNMENT << "\n";
+    usersim_throw_exception(ss.str());
+}
+
+void
+ExRaiseDatatypeMisalignment()
+{
+    ExRaiseDatatypeMisalignmentCPP();
 }

--- a/src/ke.cpp
+++ b/src/ke.cpp
@@ -391,8 +391,8 @@ KeBugCheckCPP(ULONG bug_check_code)
     KeBugCheckExCPP(bug_check_code, 0, 0, 0, 0);
 }
 
-static void
-_throw_exception(_In_ std::string message)
+void
+usersim_throw_exception(_In_ std::string message)
 {
     throw std::exception(message.c_str());
 }
@@ -413,7 +413,7 @@ KeBugCheckExCPP(
         bug_check_parameter2,
         bug_check_parameter3,
         bug_check_parameter4);
-    _throw_exception(ss.str());
+    usersim_throw_exception(ss.str());
 }
 
 void

--- a/tests/ex_test.cpp
+++ b/tests/ex_test.cpp
@@ -49,3 +49,29 @@ TEST_CASE("ExFreePool null", "[ex]")
             0);
     }
 }
+
+TEST_CASE("ExRaiseAccessViolation", "[ex]")
+{
+    try {
+        ExRaiseAccessViolationCPP();
+        REQUIRE(FALSE);
+    } catch (std::exception e) {
+        PCSTR message = e.what();
+        PCSTR ex = message + strlen("Exception: ");
+        int64_t code = _atoi64(ex);
+        REQUIRE(code == STATUS_ACCESS_VIOLATION);
+    }
+}
+
+TEST_CASE("ExRaiseDatatypeMisalignment", "[ex]")
+{
+    try {
+        ExRaiseDatatypeMisalignmentCPP();
+        REQUIRE(FALSE);
+    } catch (std::exception e) {
+        PCSTR message = e.what();
+        PCSTR ex = message + strlen("Exception: ");
+        int64_t code = _atoi64(ex);
+        REQUIRE(code == STATUS_DATATYPE_MISALIGNMENT);
+    }
+}


### PR DESCRIPTION
Add support for the following kernel APIs:
* ExRaiseAccessViolation
* ExRaiseDatatypeMisalignment
* ProbeForRead
* ProbeForWrite (note that MSDN says this is deprecated and code should just use ProbeForRead instead, hence the implementation, but ebpf-for-windows uses ProbeForWrite)