### PR TITLE
Add KfRaiseIrql and some Etw APIs

### DIFF
--- a/inc/TraceLoggingProvider.h
+++ b/inc/TraceLoggingProvider.h
@@ -121,6 +121,9 @@ extern "C"
 
 #define _tlgWriteTransfer_EtwWriteTransfer(...)
 
+    USERSIM_API void
+    EtwWriteTransfer(_In_ const TraceLoggingHProvider hProvider, _In_z_ const char* eventName, size_t argc, ...);
+
 #ifdef __cplusplus
 }
 #endif

--- a/inc/TraceLoggingProvider.h
+++ b/inc/TraceLoggingProvider.h
@@ -121,9 +121,6 @@ extern "C"
 
 #define _tlgWriteTransfer_EtwWriteTransfer(...)
 
-    USERSIM_API void
-    EtwWriteTransfer(_In_ const TraceLoggingHProvider hProvider, _In_z_ const char* eventName, size_t argc, ...);
-
 #ifdef __cplusplus
 }
 #endif

--- a/inc/usersim/etw.h
+++ b/inc/usersim/etw.h
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+#pragma once
+#include "usersim/ke.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef _IRQL_requires_max_(PASSIVE_LEVEL) _IRQL_requires_same_ VOID NTAPI ETWENABLECALLBACK(
+    _In_ LPCGUID SourceId,
+    _In_ ULONG ControlCode,
+    _In_ UCHAR Level,
+    _In_ ULONGLONG MatchAnyKeyword,
+    _In_ ULONGLONG MatchAllKeyword,
+    _In_opt_ PEVENT_FILTER_DESCRIPTOR FilterData,
+    _Inout_opt_ PVOID CallbackContext);
+
+typedef ETWENABLECALLBACK* PETWENABLECALLBACK;
+
+_IRQL_requires_max_(PASSIVE_LEVEL) USERSIM_API NTSTATUS EtwRegister(
+    _In_ LPCGUID provider_id,
+    _In_opt_ PETWENABLECALLBACK enable_callback,
+    _In_opt_ PVOID callback_context,
+    _Out_ PREGHANDLE reg_handle);
+
+_IRQL_requires_max_(PASSIVE_LEVEL) USERSIM_API NTSTATUS EtwUnregister(_In_ REGHANDLE reg_handle);
+
+_IRQL_requires_max_(HIGH_LEVEL) USERSIM_API NTSTATUS EtwWriteTransfer(
+    REGHANDLE reg_handle,
+    _In_ EVENT_DESCRIPTOR const* descriptor,
+    _In_opt_ LPCGUID activity_id,
+    _In_opt_ LPCGUID related_activity_id,
+    _In_range_(2, 128) UINT32 data_size,
+    _Inout_cap_(cData) EVENT_DATA_DESCRIPTOR* data);
+
+USERSIM_API NTSTATUS
+EtwSetInformation(
+    REGHANDLE reg_handle,
+    EVENT_INFO_CLASS information_class,
+    _In_opt_ PVOID information,
+    UINT16 const information_size);
+
+#ifdef __cplusplus
+}
+#endif

--- a/inc/usersim/ke.h
+++ b/inc/usersim/ke.h
@@ -3,9 +3,10 @@
 
 #pragma once
 #include "..\src\platform.h"
-#include <string>
 
 #if defined(__cplusplus)
+#include <string>
+
 extern "C"
 {
 #endif

--- a/inc/usersim/ke.h
+++ b/inc/usersim/ke.h
@@ -68,6 +68,10 @@ extern "C"
     KeRaiseIrql(_In_ KIRQL new_irql, _Out_ PKIRQL old_irql);
 
     USERSIM_API
+    _IRQL_requires_max_(HIGH_LEVEL) _IRQL_raises_(new_irql) _IRQL_saves_ KIRQL
+    KfRaiseIrql(_In_ KIRQL new_irql);
+
+    USERSIM_API
     KIRQL
     KeRaiseIrqlToDpcLevel();
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_library(usersim SHARED
   dllmain.cpp
+  etw.cpp
   ex.cpp
   fault_injection.cpp
   fault_injection.h

--- a/src/etw.cpp
+++ b/src/etw.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#include "platform.h"
+#include "usersim/etw.h"
+
+typedef struct
+{
+    GUID provider_id;
+    PETWENABLECALLBACK enable_callback;
+    PVOID callback_context;
+} usersim_etw_provider_t;
+
+_IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS EtwRegister(
+    _In_ LPCGUID provider_id,
+    _In_opt_ PETWENABLECALLBACK enable_callback,
+    _In_opt_ PVOID callback_context,
+    _Out_ PREGHANDLE reg_handle)
+{
+    usersim_etw_provider_t* provider = (usersim_etw_provider_t*)usersim_allocate(sizeof(*provider));
+    if (provider == nullptr) {
+        return STATUS_NO_MEMORY;
+    }
+    provider->provider_id = *provider_id;
+    provider->enable_callback = enable_callback;
+    provider->callback_context = callback_context;
+    *reg_handle = (uintptr_t)provider;
+    return STATUS_SUCCESS;
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS EtwUnregister(_In_ REGHANDLE reg_handle)
+{
+    usersim_free((void*)(uintptr_t)reg_handle);
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+EtwWriteTransfer(
+    REGHANDLE reg_handle,
+    _In_ EVENT_DESCRIPTOR const* desc,
+    _In_opt_ LPCGUID activity_id,
+    _In_opt_ LPCGUID related_activity_id,
+    _In_range_(2, 128) UINT32 data_size,
+    _Inout_cap_(cData) EVENT_DATA_DESCRIPTOR* data)
+{
+    usersim_etw_provider_t* provider = (usersim_etw_provider_t*)reg_handle;
+
+    // TODO(#70): implement similar to usersim_trace_logging_write().
+    UNREFERENCED_PARAMETER(provider);
+    UNREFERENCED_PARAMETER(desc);
+    UNREFERENCED_PARAMETER(activity_id);
+    UNREFERENCED_PARAMETER(related_activity_id);
+    UNREFERENCED_PARAMETER(data_size);
+    UNREFERENCED_PARAMETER(data);
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+EtwSetInformation(
+    REGHANDLE reg_handle, EVENT_INFO_CLASS information_class, _In_opt_ PVOID information, UINT16 const information_size)
+{
+    UNREFERENCED_PARAMETER(reg_handle);
+    UNREFERENCED_PARAMETER(information_class);
+    UNREFERENCED_PARAMETER(information);
+    UNREFERENCED_PARAMETER(information_size);
+    return STATUS_SUCCESS;
+}

--- a/src/platform_user.cpp
+++ b/src/platform_user.cpp
@@ -1157,3 +1157,9 @@ usersim_trace_logging_write(_In_ const TraceLoggingHProvider hProvider, _In_z_ c
 
     printf("}\n");
 }
+
+void
+EtwWriteTransfer(_In_ const TraceLoggingHProvider hProvider, _In_z_ const char* eventName, size_t argc, ...)
+{
+    usersim_trace_logging_write(hProvider, eventName, argc, nullptr);
+}

--- a/src/platform_user.cpp
+++ b/src/platform_user.cpp
@@ -1157,9 +1157,3 @@ usersim_trace_logging_write(_In_ const TraceLoggingHProvider hProvider, _In_z_ c
 
     printf("}\n");
 }
-
-void
-EtwWriteTransfer(_In_ const TraceLoggingHProvider hProvider, _In_z_ const char* eventName, size_t argc, ...)
-{
-    usersim_trace_logging_write(hProvider, eventName, argc, nullptr);
-}

--- a/src/usersim.vcxproj
+++ b/src/usersim.vcxproj
@@ -193,6 +193,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp" />
+    <ClCompile Include="etw.cpp" />
     <ClCompile Include="ex.cpp" />
     <ClCompile Include="fault_injection.cpp" />
     <ClCompile Include="fwp_um.cpp" />
@@ -214,6 +215,7 @@
   <ItemGroup>
     <ClInclude Include="..\inc\TraceLoggingProvider.h" />
     <ClInclude Include="..\inc\usersim\common.h" />
+    <ClInclude Include="..\inc\usersim\etw.h" />
     <ClInclude Include="..\inc\usersim\ex.h" />
     <ClInclude Include="..\inc\usersim\fwp_test.h" />
     <ClInclude Include="..\inc\usersim\wdf.h" />

--- a/src/usersim.vcxproj.filters
+++ b/src/usersim.vcxproj.filters
@@ -69,6 +69,9 @@
     <ClCompile Include="dllmain.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="etw.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="fwp_um.h">
@@ -132,6 +135,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\inc\usersim\wdf.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\inc\usersim\etw.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(Catch2)
 
 add_executable(usersim_tests
+  etw_test.cpp
   ex_test.cpp
   ke_test.cpp
   mm_test.cpp

--- a/tests/etw_test.cpp
+++ b/tests/etw_test.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#if !defined(CMAKE_NUGET)
+#include <catch2/catch_all.hpp>
+#else
+#include <catch2/catch.hpp>
+#endif
+#include "usersim/etw.h"
+
+TEST_CASE("EtwRegister", "[etw]")
+{
+    GUID guid = {};
+    REGHANDLE reg_handle;
+    REQUIRE(EtwRegister(&guid, nullptr, nullptr, &reg_handle) == STATUS_SUCCESS);
+    REQUIRE(EtwUnregister(reg_handle) == STATUS_SUCCESS);
+}

--- a/tests/ke_test.cpp
+++ b/tests/ke_test.cpp
@@ -36,6 +36,23 @@ TEST_CASE("irql", "[ke]")
     REQUIRE(KeGetCurrentIrql() == PASSIVE_LEVEL);
 }
 
+TEST_CASE("KfRaiseIrql", "[ke]")
+{
+    REQUIRE(KeGetCurrentIrql() == PASSIVE_LEVEL);
+
+    KIRQL old_irql;
+    old_irql = KfRaiseIrql(DISPATCH_LEVEL);
+    REQUIRE(old_irql == PASSIVE_LEVEL);
+    REQUIRE(KeGetCurrentIrql() == DISPATCH_LEVEL);
+
+    old_irql = KfRaiseIrql(DISPATCH_LEVEL);
+    REQUIRE(old_irql == DISPATCH_LEVEL);
+    REQUIRE(KeGetCurrentIrql() == DISPATCH_LEVEL);
+
+    KeLowerIrql(PASSIVE_LEVEL);
+    REQUIRE(KeGetCurrentIrql() == PASSIVE_LEVEL);
+}
+
 TEST_CASE("spin lock", "[ke]")
 {
     KSPIN_LOCK lock;

--- a/tests/mm_test.cpp
+++ b/tests/mm_test.cpp
@@ -52,12 +52,6 @@ TEST_CASE("IoAllocateMdl", "[mm]")
     ExFreePoolWithTag(buffer, tag);
 }
 
-int
-test_probe_for_read_exception_filter(ULONG code, _In_ struct _EXCEPTION_POINTERS *ep)
-{
-    return EXCEPTION_EXECUTE_HANDLER;
-}
-
 ULONG
 test_probe_for_read(_In_ const volatile void* address, SIZE_T length, ULONG alignment)
 {

--- a/tests/tests.vcxproj
+++ b/tests/tests.vcxproj
@@ -152,6 +152,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="etw_test.cpp" />
     <ClCompile Include="ex_test.cpp" />
     <ClCompile Include="ke_test.cpp" />
     <ClCompile Include="mm_test.cpp" />

--- a/tests/tests.vcxproj.filters
+++ b/tests/tests.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClCompile Include="se_test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="etw_test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
* Add support for `KfRaiseIrql()`, including tests.  The DDK just defines `KeRaiseIrql()` as an inline wrapper around `KfRaiseIrql()` so we need to expose `KfRaiseIrql()` when linking.
* Add support for `EtwRegister()` and `EtwUnregister()`, including tests.
* Add empty stubs for `EtwWriteTransfer()` and `EtwSetInformation()`.
* Remove unused function `test_probe_for_read_exception_filter()`.

Addresses parts of #69 #70