### PR TITLE
Add Zw registry overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ To use this repository from another project:
 7. Disable warning 4324 (structure was padded due to alignment) in the project properties, by adding 4324 to
    Configuration Properties -> C/C++ -> Advanced -> Disable Specific Warnings.
 8. Make sure you are not linking with any kernel libs, since they aren't usable by DLLs.
+9. Give usersim.lib preference over ntdll.lib as follows:
+   Under Configuration Properties -> Linker -> Input -> Ignore Specific Default Libraries, add ntdll.lib.
+   Under Configuration Properties -> Linker -> Input -> Additional Dependencies, add usersim.lib before ntdll.lib.
 
 ### Leak Detection
 

--- a/inc/usersim/io.h
+++ b/inc/usersim/io.h
@@ -23,7 +23,7 @@ extern "C"
         CustomPriorityWorkQueue = 32
     } WORK_QUEUE_TYPE;
 
-    typedef struct _DEVICE_OBJECT DEVICE_OBJECT;
+    typedef struct _DEVICE_OBJECT DEVICE_OBJECT, *PDEVICE_OBJECT;
 
     typedef struct _DRIVER_OBJECT DRIVER_OBJECT, *PDRIVER_OBJECT;
 

--- a/inc/usersim/rtl.h
+++ b/inc/usersim/rtl.h
@@ -153,7 +153,15 @@ extern "C"
         _Out_ PUNICODE_STRING destination_string,
         _In_opt_z_ __drv_aliasesMem PCWSTR source_string);
 
-    typedef struct _object_attributes OBJECT_ATTRIBUTES, *POBJECT_ATTRIBUTES;
+    typedef struct _OBJECT_ATTRIBUTES
+    {
+        ULONG Length;
+        HANDLE RootDirectory;
+        PUNICODE_STRING ObjectName;
+        ULONG Attributes;
+        SECURITY_DESCRIPTOR* SecurityDescriptor;
+        SECURITY_QUALITY_OF_SERVICE* SecurityQualityOfService;
+    } OBJECT_ATTRIBUTES, *POBJECT_ATTRIBUTES;
 
 // Include Rtl* implementations from ntdll.lib.
 #pragma comment(lib, "ntdll.lib")

--- a/inc/usersim/wdf.h
+++ b/inc/usersim/wdf.h
@@ -47,6 +47,7 @@ extern "C"
     struct _DRIVER_OBJECT
     {
         WDF_DRIVER_CONFIG config;
+        PDEVICE_OBJECT device;
     };
 
 #define WDF_DRIVER_GLOBALS_NAME_LEN (32)
@@ -130,7 +131,6 @@ extern "C"
         _In_ PWDF_FILEOBJECT_CONFIG file_object_config,
         _In_opt_ PWDF_OBJECT_ATTRIBUTES file_object_attributes);
 
-
     typedef NTSTATUS(FN_WDFDEVICE_WDM_IRP_PREPROCESS)(_In_ WDFDEVICE device, _Inout_ IRP* irp);
     typedef FN_WDFDEVICE_WDM_IRP_PREPROCESS* PFN_WDFDEVICE_WDM_IRP_PREPROCESS;
 
@@ -163,6 +163,12 @@ extern "C"
         _In_opt_ PWDF_OBJECT_ATTRIBUTES queue_attributes,
         _Out_opt_ WDFQUEUE* queue);
 
+    typedef _IRQL_requires_max_(DISPATCH_LEVEL)
+        VOID(WdfControlFinishInitializing_t)(_In_ PWDF_DRIVER_GLOBALS driver_globals, _In_ WDFDEVICE device);
+
+    typedef _IRQL_requires_max_(DISPATCH_LEVEL)
+        PDEVICE_OBJECT(WdfDeviceWdmGetDeviceObject_t)(_In_ PWDF_DRIVER_GLOBALS driver_globals, _In_ WDFDEVICE device);
+
     typedef HANDLE WDFOBJECT;
 
     typedef _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -171,6 +177,8 @@ extern "C"
     typedef enum _WDFFUNCENUM
     {
         WdfControlDeviceInitAllocateTableIndex = 25,
+        WdfControlFinishInitializingTableIndex = 27,
+        WdfDeviceWdmGetDeviceObjectTableIndex = 31,
         WdfDeviceInitFreeTableIndex = 54,
         WdfDeviceInitSetDeviceTypeTableIndex = 66,
         WdfDeviceInitAssignNameTableIndex = 67,

--- a/inc/usersim/zw.h
+++ b/inc/usersim/zw.h
@@ -7,9 +7,8 @@
 extern "C"
 {
 #endif
-
-    USERSIM_API
-    _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS ZwCreateKey(
+    USERSIM_API _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS
+    ZwCreateKey(
         _Out_ PHANDLE key_handle,
         _In_ ACCESS_MASK desired_access,
         _In_ POBJECT_ATTRIBUTES object_attributes,
@@ -18,9 +17,14 @@ extern "C"
         _In_ ULONG create_options,
         _Out_opt_ PULONG disposition);
 
-    USERSIM_API NTSTATUS
-    ZwDeleteKey(
-        _In_ HANDLE key_handle);
+    // The following APIs are exported by ntdll.dll but the prototypes
+    // are not in system headers, so define them here.
+
+    NTSTATUS
+    ZwDeleteKey(_In_ HANDLE key_handle);
+
+    NTSTATUS
+    ZwClose(_In_ HANDLE handle);
 
 #if defined(__cplusplus)
 }

--- a/inc/usersim/zw.h
+++ b/inc/usersim/zw.h
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+#pragma once
+#include "usersim/rtl.h" // For UNICODE_STRING
+
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
+    USERSIM_API
+    _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS ZwCreateKey(
+        _Out_ PHANDLE key_handle,
+        _In_ ACCESS_MASK desired_access,
+        _In_ POBJECT_ATTRIBUTES object_attributes,
+        _Reserved_ ULONG title_index,
+        _In_opt_ PUNICODE_STRING class_string,
+        _In_ ULONG create_options,
+        _Out_opt_ PULONG disposition);
+
+    USERSIM_API NTSTATUS
+    ZwDeleteKey(
+        _In_ HANDLE key_handle);
+
+#if defined(__cplusplus)
+}
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(usersim SHARED
   tracelog.h
   utilities.h
   wdf.cpp
+  zw.cpp
   Source.def
 )
 

--- a/src/usersim.vcxproj
+++ b/src/usersim.vcxproj
@@ -212,6 +212,7 @@
     <ClCompile Include="se.cpp" />
     <ClCompile Include="tracelog.c" />
     <ClCompile Include="wdf.cpp" />
+    <ClCompile Include="zw.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\inc\TraceLoggingProvider.h" />
@@ -221,6 +222,7 @@
     <ClInclude Include="..\inc\usersim\fwp_test.h" />
     <ClInclude Include="..\inc\usersim\ob.h" />
     <ClInclude Include="..\inc\usersim\wdf.h" />
+    <ClInclude Include="..\inc\usersim\zw.h" />
     <ClInclude Include="fault_injection.h" />
     <ClInclude Include="framework.h" />
     <ClInclude Include="fwp_um.h" />

--- a/src/usersim.vcxproj.filters
+++ b/src/usersim.vcxproj.filters
@@ -75,6 +75,9 @@
     <ClCompile Include="ob.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="zw.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="fwp_um.h">
@@ -144,6 +147,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\inc\usersim\ob.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\inc\usersim\zw.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/zw.cpp
+++ b/src/zw.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+#include "fault_injection.h"
+#include "usersim/zw.h"
+#include "utilities.h"
+#include <string>
+
+_IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS ZwCreateKey(
+    _Out_ PHANDLE key_handle,
+    _In_ ACCESS_MASK desired_access,
+    _In_ POBJECT_ATTRIBUTES object_attributes,
+    _Reserved_ ULONG title_index,
+    _In_opt_ PUNICODE_STRING class_string,
+    _In_ ULONG create_options,
+    _Out_opt_ PULONG disposition)
+{
+    if (usersim_fault_injection_inject_fault()) {
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    if (class_string != nullptr || title_index != 0) {
+        return STATUS_NOT_SUPPORTED;
+    }
+
+    UNREFERENCED_PARAMETER(create_options);
+
+    HKEY root_key = (HKEY)object_attributes->RootDirectory;
+    std::wstring relative_path = object_attributes->ObjectName->Buffer;
+    PCWSTR hklm_path = L"\\Registry\\Machine\\";
+    PCWSTR hkcu_path = L"\\Registry\\User\\";
+    if (relative_path.starts_with(hklm_path)) {
+        root_key = HKEY_LOCAL_MACHINE;
+        relative_path = relative_path.substr(wcslen(hklm_path));
+    } else if (relative_path.starts_with(hkcu_path)) {
+        root_key = HKEY_CURRENT_USER;
+        relative_path = relative_path.substr(wcslen(hkcu_path));
+    }
+
+    ULONG result = RegCreateKeyExW(
+        root_key,
+        relative_path.c_str(),
+        0, // Reserved
+        (class_string ? class_string->Buffer : nullptr),
+        REG_OPTION_VOLATILE,
+        desired_access,
+        nullptr,
+        (PHKEY)key_handle,
+        disposition);
+    if (result == ERROR_ACCESS_DENIED && root_key == HKEY_LOCAL_MACHINE) {
+        // Try again with HKCU, so access to \Registry\Machine will succeed
+        // like it should when called from "kernel-mode" code.
+        root_key = HKEY_CURRENT_USER;
+        result = RegCreateKeyExW(
+            root_key,
+            relative_path.c_str(),
+            0, // Reserved
+            (class_string ? class_string->Buffer : nullptr),
+            REG_OPTION_VOLATILE,
+            desired_access,
+            nullptr,
+            (PHKEY)key_handle,
+            disposition);
+    }
+
+    return win32_error_code_to_usersim_result(result);
+}
+
+NTSTATUS
+ZwDeleteKey(_In_ HANDLE key_handle)
+{
+    ULONG result = RegDeleteKey((HKEY)key_handle, L"");
+    return win32_error_code_to_usersim_result(result);
+}

--- a/tests/tests.vcxproj
+++ b/tests/tests.vcxproj
@@ -129,7 +129,8 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ntdll.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>usersim.lib;ntdll.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir);$(VC_LibraryPath_VC_x64_Desktop);%(Link.AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -148,7 +149,8 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ntdll.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>usersim.lib;ntdll.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir);$(VC_LibraryPath_VC_x64_Desktop);%(Link.AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -161,6 +163,7 @@
     <ClCompile Include="rtl_test.cpp" />
     <ClCompile Include="se_test.cpp" />
     <ClCompile Include="wdf_test.cpp" />
+    <ClCompile Include="zw_test.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tests/tests.vcxproj.filters
+++ b/tests/tests.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClCompile Include="ob_test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="zw_test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tests/zw_test.cpp
+++ b/tests/zw_test.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#if !defined(CMAKE_NUGET)
+#include <catch2/catch_all.hpp>
+#else
+#include <catch2/catch.hpp>
+#endif
+#include "usersim/zw.h"
+
+#define ZwClose CloseHandle
+
+static void
+_test_zwcreatekey(_In_ PCWSTR path)
+{
+    NTSTATUS status;
+    HANDLE key_handle = nullptr;
+    UNICODE_STRING object_name;
+    RtlInitUnicodeString(&object_name, path);
+    OBJECT_ATTRIBUTES object_attributes = {.Length = sizeof(OBJECT_ATTRIBUTES), .ObjectName = &object_name};
+    ULONG disposition;
+    status = ZwCreateKey(&key_handle, KEY_WRITE, &object_attributes, 0, nullptr, REG_OPTION_VOLATILE, &disposition);
+    REQUIRE(status == STATUS_SUCCESS);
+    REQUIRE((disposition == REG_CREATED_NEW_KEY || disposition == REG_OPENED_EXISTING_KEY));
+    REQUIRE(key_handle != nullptr);
+
+    ZwClose(key_handle);
+
+    // Try creating when already exists.
+    status = ZwCreateKey(&key_handle, KEY_WRITE, &object_attributes, 0, nullptr, REG_OPTION_VOLATILE, &disposition);
+    REQUIRE(status == STATUS_SUCCESS);
+    REQUIRE(disposition == REG_OPENED_EXISTING_KEY);
+
+    ZwDeleteKey(key_handle);
+    ZwClose(key_handle);
+}
+
+TEST_CASE("ZwCreateKey HKCU", "[zw]")
+{
+    // In kernel-mode code, HKCU is \Registry\User.
+    _test_zwcreatekey(L"\\Registry\\User\\Software\\eBPF\\Test");
+}
+
+TEST_CASE("ZwCreateKey HKLM", "[zw]")
+{
+    // In kernel-mode code, HKLM is \Registry\Machine.
+    // Usersim will internally use HKCU if the test is not run as admin.
+    _test_zwcreatekey(L"\\Registry\\Machine\\Software\\eBPF\\Test");
+}

--- a/tests/zw_test.cpp
+++ b/tests/zw_test.cpp
@@ -27,7 +27,8 @@ _test_zwcreatekey(_In_ PCWSTR path)
     ZwClose(key_handle);
 
     // Try creating when already exists.
-    status = ZwCreateKey(&key_handle, KEY_WRITE, &object_attributes, 0, nullptr, REG_OPTION_VOLATILE, &disposition);
+    status =
+        ZwCreateKey(&key_handle, KEY_QUERY_VALUE, &object_attributes, 0, nullptr, REG_OPTION_VOLATILE, &disposition);
     REQUIRE(status == STATUS_SUCCESS);
     REQUIRE(disposition == REG_OPENED_EXISTING_KEY);
 
@@ -38,12 +39,12 @@ _test_zwcreatekey(_In_ PCWSTR path)
 TEST_CASE("ZwCreateKey HKCU", "[zw]")
 {
     // In kernel-mode code, HKCU is \Registry\User.
-    _test_zwcreatekey(L"\\Registry\\User\\Software\\eBPF\\Test");
+    _test_zwcreatekey(L"\\Registry\\User\\Software\\Usersim\\Test");
 }
 
 TEST_CASE("ZwCreateKey HKLM", "[zw]")
 {
     // In kernel-mode code, HKLM is \Registry\Machine.
     // Usersim will internally use HKCU if the test is not run as admin.
-    _test_zwcreatekey(L"\\Registry\\Machine\\Software\\eBPF\\Test");
+    _test_zwcreatekey(L"\\Registry\\Machine\\Software\\Usersim\\Test");
 }

--- a/usersim_dll_skeleton/dll_skeleton.c
+++ b/usersim_dll_skeleton/dll_skeleton.c
@@ -40,6 +40,12 @@ static DRIVER_OBJECT _driver_object = {0};
         if (driver->config.EvtDriverUnload != NULL) {
             driver->config.EvtDriverUnload(driver);
         }
+
+        // Free device, which will free the control device object.
+        WdfObjectDelete_t* WdfObjectDelete = (WdfObjectDelete_t*)UsersimWdfFunctions[WdfObjectDeleteTableIndex];
+        WdfObjectDelete(UsersimWdfDriverGlobals, driver->device);
+        driver->device = NULL;
+
         WdfDriverGlobals->Driver = NULL;
     }
 


### PR DESCRIPTION
Override calls to HKLM to use HKCU for now. This is because kernel code has write access to HKLM, so to accurately simulate such calls from a normal test app, we redirect them to HKCU if HKLM access fails.

Also add a couple more Wdf functions needed by ebpf-for-windows