### PR TITLE
Implement kevent

### DIFF
--- a/inc/usersim/ke.h
+++ b/inc/usersim/ke.h
@@ -23,6 +23,7 @@ typedef enum _usersim_object_type
     USERSIM_OBJECT_TYPE_UNKNOWN,
     USERSIM_OBJECT_TYPE_SEMAPHORE,
     USERSIM_OBJECT_TYPE_TIMER,
+    USERSIM_OBJECT_TYPE_EVENT,
 } usersim_object_type_t;
 
 typedef enum
@@ -172,6 +173,38 @@ void
 usersim_free_semaphores();
 
 #pragma endregion semaphores
+
+#pragma region events
+
+typedef enum _EVENT_TYPE
+{
+    NotificationEvent,
+    SynchronizationEvent
+} EVENT_TYPE;
+
+typedef struct _kevent
+{
+    usersim_object_type_t object_type;
+    EVENT_TYPE type;
+    KSPIN_LOCK spin_lock;
+    LONG signalled;
+} KEVENT;
+typedef KEVENT* PKEVENT;
+typedef KEVENT* PRKEVENT;
+
+USERSIM_API
+void
+KeInitializeEvent(_Out_ PKEVENT event, _In_ EVENT_TYPE type, _In_ BOOLEAN initial_state);
+
+USERSIM_API
+LONG
+KeSetEvent(_Inout_ PRKEVENT Event, _In_ KPRIORITY Increment, _In_ _Literal_ BOOLEAN Wait);
+
+USERSIM_API
+void
+KeClearEvent(_Inout_ PRKEVENT Event);
+
+#pragma endregion events
 
 USERSIM_API
 _IRQL_requires_max_(APC_LEVEL) NTKERNELAPI VOID

--- a/inc/usersim/ke.h
+++ b/inc/usersim/ke.h
@@ -187,7 +187,7 @@ typedef struct _kevent
     usersim_object_type_t object_type;
     EVENT_TYPE type;
     KSPIN_LOCK spin_lock;
-    LONG signalled;
+    BOOLEAN signaled;
 } KEVENT;
 typedef KEVENT* PKEVENT;
 typedef KEVENT* PRKEVENT;
@@ -198,11 +198,11 @@ KeInitializeEvent(_Out_ PKEVENT event, _In_ EVENT_TYPE type, _In_ BOOLEAN initia
 
 USERSIM_API
 LONG
-KeSetEvent(_Inout_ PRKEVENT Event, _In_ KPRIORITY Increment, _In_ _Literal_ BOOLEAN Wait);
+KeSetEvent(_Inout_ PRKEVENT event, _In_ KPRIORITY increment, _In_ _Literal_ BOOLEAN wait);
 
 USERSIM_API
 void
-KeClearEvent(_Inout_ PRKEVENT Event);
+KeClearEvent(_Inout_ PRKEVENT event);
 
 #pragma endregion events
 

--- a/src/ke.cpp
+++ b/src/ke.cpp
@@ -25,6 +25,9 @@ thread_local GROUP_AFFINITY _usersim_dispatch_previous_affinity;
 static uint32_t _usersim_original_priority_class;
 static std::vector<std::mutex> _usersim_dispatch_locks;
 
+static NTSTATUS
+_wait_for_kevent(_Inout_ KEVENT* event, _In_opt_ PLARGE_INTEGER timeout);
+
 usersim_result_t
 usersim_initialize_irql()
 {
@@ -304,7 +307,7 @@ _IRQL_requires_min_(PASSIVE_LEVEL) _When_((timeout == NULL || timeout->QuadPart 
         timeout_ms = (DWORD)(timeout->QuadPart / 10000);
     }
 
-    // Unify semaphore and event handling once https://github.com/microsoft/usersim/issues/95
+    // TODO: Unify semaphore and event handling once https://github.com/microsoft/usersim/issues/95
     // is fixed.
 
     // Get handle from object.
@@ -325,46 +328,7 @@ _IRQL_requires_min_(PASSIVE_LEVEL) _When_((timeout == NULL || timeout->QuadPart 
         }
     }
     case USERSIM_OBJECT_TYPE_EVENT: {
-        PRKEVENT event = (PRKEVENT)object;
-        uint64_t qpc_time_stamp = 0;
-        // Compute the end time for the wait, if any.
-        uint64_t start_time = KeQueryInterruptTimePrecise(&qpc_time_stamp);
-        uint64_t end_time;
-        if (timeout == nullptr) {
-            end_time = UINT64_MAX;
-        } else if (timeout->QuadPart > 0) {
-            end_time = timeout->QuadPart;
-        } else {
-            end_time = start_time - timeout->QuadPart;
-        }
-
-        for (;;) {
-            // Compute the remaining time in milliseconds for the wait.
-            timeout_ms = (DWORD)((end_time - start_time) / 10000);
-
-            KIRQL old_irql;
-            KeAcquireSpinLock(&event->spin_lock, &old_irql);
-            if (event->signalled) {
-                if (event->type == SynchronizationEvent) {
-                    event->signalled = 0;
-                }
-                KeReleaseSpinLock(&event->spin_lock, old_irql);
-                return STATUS_SUCCESS;
-            } else {
-                KeReleaseSpinLock(&event->spin_lock, old_irql);
-                // Wait for event->signalled to change.
-                uint64_t old_state = event->signalled;
-                bool wait_return = WaitOnAddress(&event->signalled, &old_state, sizeof(event->signalled), timeout_ms);
-                if (!wait_return) {
-                    return STATUS_TIMEOUT;
-                }
-            }
-            // Check if the wait timed out outside of the WaitOnAddress() call.
-            start_time = KeQueryInterruptTimePrecise(&qpc_time_stamp);
-            if (start_time >= end_time) {
-                return STATUS_TIMEOUT;
-            }
-        }
+        return _wait_for_kevent((KEVENT*)object, timeout);
     }
     default:
         ASSERT(FALSE);
@@ -830,7 +794,7 @@ USERSIM_API
 void
 KeInitializeEvent(_Out_ PKEVENT event, _In_ EVENT_TYPE type, _In_ BOOLEAN initial_state)
 {
-    event->signalled = initial_state ? 1 : 0;
+    event->signaled = initial_state;
     event->type = type;
     event->object_type = USERSIM_OBJECT_TYPE_EVENT;
     KeInitializeSpinLock(&event->spin_lock);
@@ -848,13 +812,13 @@ KeSetEvent(_Inout_ PKEVENT event, _In_ KPRIORITY increment, _In_ BOOLEAN wait)
     LONG previous_state;
     KeAcquireSpinLock(&event->spin_lock, &old_irql);
 
-    previous_state = event->signalled;
-    event->signalled = 1;
+    previous_state = event->signaled ? 1 : 0;
+    event->signaled = TRUE;
 
     KeReleaseSpinLock(&event->spin_lock, old_irql);
 
     // Wake up any waiters.
-    WakeByAddressAll(&event->signalled);
+    WakeByAddressAll(&event->signaled);
     return previous_state;
 }
 
@@ -866,9 +830,65 @@ KeClearEvent(_Inout_ PKEVENT event)
     KIRQL old_irql;
     KeAcquireSpinLock(&event->spin_lock, &old_irql);
 
-    event->signalled = 0;
+    event->signaled = FALSE;
 
     KeReleaseSpinLock(&event->spin_lock, old_irql);
+}
+
+/**
+ * @brief Wait for an event to be signaled.
+ *
+ * @param[in,out] event The KEVENT to wait on.
+ * @param[in,opt] timeout The timeout for the wait, or nullptr for no timeout.
+ * @retval STATUS_SUCCESS The event was signaled.
+ * @retval STATUS_TIMEOUT The wait timed out.
+ */
+static NTSTATUS
+_wait_for_kevent(_Inout_ KEVENT* event, _In_opt_ PLARGE_INTEGER timeout)
+{
+    uint64_t qpc_time_stamp = 0;
+    // Compute the end time for the wait, if any.
+    uint64_t start_time = KeQueryInterruptTimePrecise(&qpc_time_stamp);
+    uint64_t end_time;
+    if (timeout == nullptr) {
+        end_time = UINT64_MAX;
+    } else if (timeout->QuadPart > 0) {
+        end_time = timeout->QuadPart;
+    } else {
+        end_time = start_time - timeout->QuadPart;
+    }
+
+    for (;;) {
+        // Compute the remaining time in milliseconds for the wait.
+        DWORD timeout_ms = (DWORD)((end_time - start_time) / 10000);
+
+        KIRQL old_irql;
+        KeAcquireSpinLock(&event->spin_lock, &old_irql);
+        // Check if the event is signaled.
+        if (event->signaled) {
+            // Clear the event if it is an auto-reset event.
+            if (event->type == SynchronizationEvent) {
+                event->signaled = FALSE;
+            }
+            KeReleaseSpinLock(&event->spin_lock, old_irql);
+            return STATUS_SUCCESS;
+        } else {
+            // Capture the current state of event->signaled, so we can wait for it to change.
+            uint64_t old_state = event->signaled;
+            KeReleaseSpinLock(&event->spin_lock, old_irql);
+
+            // Wait for event->signaled to change.
+            bool wait_return = WaitOnAddress(&event->signaled, &old_state, sizeof(event->signaled), timeout_ms);
+            if (!wait_return) {
+                return STATUS_TIMEOUT;
+            }
+        }
+        // Check if the wait timed out outside of the WaitOnAddress() call.
+        start_time = KeQueryInterruptTimePrecise(&qpc_time_stamp);
+        if (start_time >= end_time) {
+            return STATUS_TIMEOUT;
+        }
+    }
 }
 
 #pragma endregion events


### PR DESCRIPTION
Note:
This implementation permits using KEVENT as a local stack variable without leaking large numbers of Win32 handles. 

It is a prerequisite to fixing https://github.com/microsoft/ebpf-for-windows/issues/2787. 