### PR TITLE
Diagnose double frees

### DIFF
--- a/cxplat/src/cxplat_winuser/leak_detector.cpp
+++ b/cxplat/src/cxplat_winuser/leak_detector.cpp
@@ -18,12 +18,12 @@ _cxplat_leak_detector::register_allocation(uintptr_t address, size_t size)
             1,
             static_cast<unsigned int>(stack.size()),
             reinterpret_cast<void**>(stack.data()),
-            &allocation.stack_hash) == 0) {
-        allocation.stack_hash = 0;
+            &allocation.alloc_stack_hash) == 0) {
+        allocation.alloc_stack_hash = 0;
     }
     _allocations[address] = allocation;
-    if (!_stack_hashes.contains(allocation.stack_hash)) {
-        _stack_hashes[allocation.stack_hash] = stack;
+    if (!_stack_hashes.contains(allocation.alloc_stack_hash)) {
+        _stack_hashes[allocation.alloc_stack_hash] = stack;
     }
 }
 
@@ -31,8 +31,68 @@ void
 _cxplat_leak_detector::unregister_allocation(uintptr_t address)
 {
     std::unique_lock<std::mutex> lock(_mutex);
+    if (!_allocations.contains(address)) {
+        auto allocation = _freed_allocations[address];
+        std::ostringstream output;
+        std::vector<uintptr_t> stack = _stack_hashes[allocation.alloc_stack_hash];
+        output << "Double-free of " << allocation.size << " bytes at " << allocation.address << std::endl;
+        _in_memory_log.push_back(output.str());
+        std::cout << output.str();
+        output.str("");
+        std::string name;
+        uint64_t displacement;
+        std::optional<uint32_t> line_number;
+        std::optional<std::string> file_name;
+        output << "  Alloc:" << std::endl;
+        for (auto address : stack) {
+            if (CXPLAT_SUCCEEDED(_cxplat_decode_symbol(address, name, displacement, line_number, file_name))) {
+                output << "    " << name << " + " << displacement;
+                if (line_number.has_value() && file_name.has_value()) {
+                    output << " (" << file_name.value() << ":" << line_number.value() << ")";
+                }
+                output << std::endl;
+            }
+            _in_memory_log.push_back(output.str());
+            std::cout << output.str();
+            output.str("");
+        }
+
+        output << "  Free:" << std::endl;
+        stack = _stack_hashes[allocation.free_stack_hash];
+        for (auto address : stack) {
+            if (CXPLAT_SUCCEEDED(_cxplat_decode_symbol(address, name, displacement, line_number, file_name))) {
+                output << "    " << name << " + " << displacement;
+                if (line_number.has_value() && file_name.has_value()) {
+                    output << " (" << file_name.value() << ":" << line_number.value() << ")";
+                }
+                output << std::endl;
+            }
+            _in_memory_log.push_back(output.str());
+            std::cout << output.str();
+            output.str("");
+        }
+
+        _in_memory_log.push_back(output.str());
+        std::cout << output.str();
+        output.str("");
+    }
     CXPLAT_RUNTIME_ASSERT(_allocations.contains(address));
+    _freed_allocations[address] = _allocations[address];
     _allocations.erase(address);
+
+    // Capture stack trace.
+    auto& allocation = _freed_allocations[address];
+    std::vector<uintptr_t> stack(1 + _stack_depth);
+    if (CaptureStackBackTrace(
+            1,
+            static_cast<unsigned int>(stack.size()),
+            reinterpret_cast<void**>(stack.data()),
+            &allocation.free_stack_hash) == 0) {
+        allocation.free_stack_hash = 0;
+    }
+    if (!_stack_hashes.contains(allocation.free_stack_hash)) {
+        _stack_hashes[allocation.free_stack_hash] = stack;
+    }
 }
 
 void
@@ -41,7 +101,7 @@ _cxplat_leak_detector::dump_leaks()
     std::unique_lock<std::mutex> lock(_mutex);
     for (auto& allocation : _allocations) {
         std::ostringstream output;
-        std::vector<uintptr_t> stack = _stack_hashes[allocation.second.stack_hash];
+        std::vector<uintptr_t> stack = _stack_hashes[allocation.second.alloc_stack_hash];
         output << "Leak of " << allocation.second.size << " bytes at " << allocation.second.address << std::endl;
         _in_memory_log.push_back(output.str());
         std::cout << output.str();
@@ -71,5 +131,6 @@ _cxplat_leak_detector::dump_leaks()
     CXPLAT_DEBUG_ASSERT(_allocations.empty());
 
     _allocations.clear();
+    _freed_allocations.clear();
     _stack_hashes.clear();
 }

--- a/cxplat/src/cxplat_winuser/leak_detector.h
+++ b/cxplat/src/cxplat_winuser/leak_detector.h
@@ -26,11 +26,13 @@ typedef class _cxplat_leak_detector
     {
         uintptr_t address;
         size_t size;
-        unsigned long stack_hash;
+        unsigned long alloc_stack_hash;
+        unsigned long free_stack_hash;
     } allocation_t;
 
     std::unordered_map<unsigned long, std::vector<uintptr_t>> _stack_hashes;
     std::unordered_map<uintptr_t, allocation_t> _allocations;
+    std::unordered_map<uintptr_t, allocation_t> _freed_allocations;
     std::mutex _mutex;
     const size_t _stack_depth = 32;
     std::vector<std::string> _in_memory_log;

--- a/cxplat/src/cxplat_winuser/leak_detector.h
+++ b/cxplat/src/cxplat_winuser/leak_detector.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <mutex>
+#include <sstream>
 #include <unordered_map>
 #include <vector>
 
@@ -22,6 +23,12 @@ typedef class _cxplat_leak_detector
     dump_leaks();
 
   private:
+    void
+    flush_output(std::ostringstream& output);
+
+    void
+    output_stack_trace(std::ostringstream& output, std::string label, unsigned long stack_hash);
+
     typedef struct _allocation
     {
         uintptr_t address;

--- a/cxplat/src/cxplat_winuser/memory_winuser.cpp
+++ b/cxplat/src/cxplat_winuser/memory_winuser.cpp
@@ -171,6 +171,9 @@ cxplat_free(_Frees_ptr_opt_ void* pointer)
     {
         return;
     }
+    if (_cxplat_leak_detector_ptr) {
+        _cxplat_leak_detector_ptr->unregister_allocation(reinterpret_cast<uintptr_t>(pointer));
+    }
     cxplat_allocation_header_t* header = _header_from_pointer(pointer);
     if (header->pool_type == CxPlatNonPagedPoolNxCacheAligned)
     {
@@ -181,9 +184,6 @@ cxplat_free(_Frees_ptr_opt_ void* pointer)
     {
         uint8_t* memory_block = _memory_block_from_unaligned_pointer(pointer);
         free(memory_block);
-    }
-    if (_cxplat_leak_detector_ptr) {
-        _cxplat_leak_detector_ptr->unregister_allocation(reinterpret_cast<uintptr_t>(pointer));
     }
 }
 


### PR DESCRIPTION
When a double-free is detected, show the original allocation stack, and the stack of the original free.

Not yet ready for review, needs cleanup and simplification first.