### PR TITLE
Add work item as an argument to the work_item_routine

### DIFF
--- a/cxplat/inc/cxplat_workitem.h
+++ b/cxplat/inc/cxplat_workitem.h
@@ -6,6 +6,9 @@ CXPLAT_EXTERN_C_BEGIN
 
 typedef struct _cxplat_preemptible_work_item cxplat_preemptible_work_item_t;
 
+typedef void(*cxplat_work_item_routine_t)(
+    _In_ cxplat_preemptible_work_item_t* work_item, _In_opt_ void* work_item_context);
+
 /**
  * @brief Create a preemptible work item.
  *
@@ -23,7 +26,7 @@ _Must_inspect_result_ cxplat_status_t
 cxplat_allocate_preemptible_work_item(
     _In_opt_ void* caller_context,
     _Outptr_ cxplat_preemptible_work_item_t** work_item,
-    _In_ void (*work_item_routine)(_In_opt_ void* work_item_context),
+    _In_ cxplat_work_item_routine_t work_item_routine,
     _In_opt_ void* work_item_context);
 
 /**

--- a/cxplat/src/cxplat_winkernel/workitem_winkernel.c
+++ b/cxplat/src/cxplat_winkernel/workitem_winkernel.c
@@ -7,7 +7,7 @@
 typedef struct _cxplat_preemptible_work_item
 {
     PIO_WORKITEM io_work_item;
-    void (*work_item_routine)(_Inout_opt_ void* work_item_context);
+    cxplat_work_item_routine_t work_item_routine;
     void* work_item_context;
 } cxplat_preemptible_work_item_t;
 
@@ -21,14 +21,14 @@ _cxplat_preemptible_routine(_In_ PDEVICE_OBJECT device_object, _In_opt_ void* co
         return;
     }
     cxplat_preemptible_work_item_t* work_item = (cxplat_preemptible_work_item_t*)context;
-    work_item->work_item_routine(work_item->work_item_context);
+    work_item->work_item_routine(work_item, work_item->work_item_context);
 }
 
 _Must_inspect_result_ cxplat_status_t
 cxplat_allocate_preemptible_work_item(
     _In_opt_ void* caller_context,
     _Outptr_ cxplat_preemptible_work_item_t** work_item,
-    _In_ void (*work_item_routine)(_In_opt_ void* work_item_context),
+    _In_ cxplat_work_item_routine_t work_item_routine,
     _In_opt_ void* work_item_context)
 {
     cxplat_status_t result = CXPLAT_STATUS_SUCCESS;

--- a/cxplat/src/cxplat_winuser/workitem_winuser.cpp
+++ b/cxplat/src/cxplat_winuser/workitem_winuser.cpp
@@ -13,7 +13,7 @@ static PTP_CLEANUP_GROUP _cleanup_group = nullptr;
 typedef struct _cxplat_preemptible_work_item
 {
     PTP_WORK work;
-    void (*work_item_routine)(_Inout_opt_ void* work_item_context);
+    cxplat_work_item_routine_t work_item_routine;
     void* work_item_context;
 } cxplat_preemptible_work_item_t;
 
@@ -27,7 +27,7 @@ _cxplat_preemptible_routine(_Inout_ PTP_CALLBACK_INSTANCE instance, _In_opt_ voi
 
     if (parameter != nullptr) {
         cxplat_preemptible_work_item_t* work_item = (cxplat_preemptible_work_item_t*)parameter;
-        work_item->work_item_routine(work_item->work_item_context);
+        work_item->work_item_routine(work_item, work_item->work_item_context);
     }
     cxplat_release_rundown_protection(&_cxplat_preemptible_work_items_rundown_reference);
 }
@@ -36,7 +36,7 @@ _Must_inspect_result_ cxplat_status_t
 cxplat_allocate_preemptible_work_item(
     _In_opt_ void* caller_context,
     _Outptr_ cxplat_preemptible_work_item_t** work_item,
-    _In_ void (*work_item_routine)(_In_opt_ void* work_item_context),
+    _In_ cxplat_work_item_routine_t work_item_routine,
     _In_opt_ void* work_item_context)
 {
     UNREFERENCED_PARAMETER(caller_context);

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -59,8 +59,9 @@ IoAllocateMdl(
 }
 
 void
-io_work_item_wrapper(_Inout_opt_ void* context)
+io_work_item_wrapper(_In_ cxplat_preemptible_work_item_t* work_item, _Inout_opt_ void* context)
 {
+    UNREFERENCED_PARAMETER(work_item);
     auto io_work_item = reinterpret_cast<const IO_WORKITEM*>(context);
     if (io_work_item) {
         io_work_item->routine(io_work_item->device_object, io_work_item->context);


### PR DESCRIPTION
Previously, if the caller wanted to free the work item within the work item routine, the caller had to store the work item pointer
in some context structure passed to the routine, but the cxplat code that calls the callback already has the work item pointer.
This PR changes the callback prototype to include the work item as an argument so the caller need not jump through that hoop.
Passing it as an argument is consistent with https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms687396(v=vs.85)

Fixes #104 