### PR TITLE
Use NT_ASSERT in winkernel

### DIFF
--- a/cxplat/inc/cxplat_common.h
+++ b/cxplat/inc/cxplat_common.h
@@ -5,15 +5,6 @@
 // Include platform-specific definitions of common defines.
 #include "cxplat_platform.h"
 
-#include <assert.h>
-
-#define CXPLAT_RUNTIME_ASSERT(x) assert(x)
-#ifdef NDEBUG
-#define CXPLAT_DEBUG_ASSERT(x) (void)(x)
-#else
-#define CXPLAT_DEBUG_ASSERT(x) assert(x)
-#endif //! NDEBUG
-
 #ifdef __cplusplus
 #define CXPLAT_NOEXCEPT noexcept
 #define CXPLAT_EXTERN_C extern "C"

--- a/cxplat/inc/winkernel/cxplat_winkernel.h
+++ b/cxplat/inc/winkernel/cxplat_winkernel.h
@@ -7,6 +7,13 @@
 #include <ntdef.h> // for NTSTATUS
 #include <ntstatus.h>
 
+#define CXPLAT_RUNTIME_ASSERT(x) NT_ASSERT(x)
+#ifdef NDEBUG
+#define CXPLAT_DEBUG_ASSERT(x) (void)(x)
+#else
+#define CXPLAT_DEBUG_ASSERT(x) NT_ASSERT(x)
+#endif //! NDEBUG
+
 // Map specific cxplat_status_t values to HRESULT values.
 #define CXPLAT_PLATFORM_STATUS_SUCCESS STATUS_SUCCESS
 #define CXPLAT_PLATFORM_STATUS_NO_MEMORY STATUS_NO_MEMORY

--- a/cxplat/inc/winuser/cxplat_winuser.h
+++ b/cxplat/inc/winuser/cxplat_winuser.h
@@ -1,7 +1,15 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 #pragma once
+#include <assert.h>
 #include <winerror.h>
+
+#define CXPLAT_RUNTIME_ASSERT(x) assert(x)
+#ifdef NDEBUG
+#define CXPLAT_DEBUG_ASSERT(x) (void)(x)
+#else
+#define CXPLAT_DEBUG_ASSERT(x) assert(x)
+#endif //! NDEBUG
 
 // Map specific cxplat_status_t values to HRESULT values.
 #define CXPLAT_PLATFORM_STATUS_SUCCESS S_OK

--- a/cxplat/src/cxplat_winkernel/cxplat_winkernel.c
+++ b/cxplat/src/cxplat_winkernel/cxplat_winkernel.c
@@ -3,6 +3,7 @@
 
 // This file contains initialization/cleanup routines for the Windows kernel-mode cxplat library.
 #include "cxplat.h"
+#include <wdm.h>
 
 static ULONG _cxplat_initialization_count = 0;
 


### PR DESCRIPTION
Instead of assuming that assert() exists on every platform, make it platform specific.