### PR TITLE
Remove non-tag-based allocation APIs

### DIFF
--- a/cxplat/cxplat_test/cxplat_memory_test.cpp
+++ b/cxplat/cxplat_test/cxplat_memory_test.cpp
@@ -42,7 +42,7 @@ TEST_CASE("reallocate unaligned", "[memory]")
     uint64_t* original_buffer = (uint64_t*)cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, 8, TEST_TAG, true);
     REQUIRE(original_buffer != nullptr);
 
-    uint64_t* new_buffer = (uint64_t*)cxplat_reallocate(original_buffer, 8, 16);
+    uint64_t* new_buffer = (uint64_t*)cxplat_reallocate_with_tag(original_buffer, 8, 16, TEST_TAG);
     REQUIRE(new_buffer != nullptr);
     REQUIRE(new_buffer[1] == 0);
 
@@ -52,10 +52,11 @@ TEST_CASE("reallocate unaligned", "[memory]")
 TEST_CASE("reallocate aligned", "[memory]")
 {
     // Try an allocation that must be cache aligned.
-    uint64_t* original_buffer = (uint64_t*)cxplat_allocate_with_tag(CxPlatNonPagedPoolNxCacheAligned, 8, TEST_TAG, true);
+    uint64_t* original_buffer =
+        (uint64_t*)cxplat_allocate_with_tag(CxPlatNonPagedPoolNxCacheAligned, 8, TEST_TAG, true);
     REQUIRE(original_buffer != nullptr);
 
-    uint64_t* new_buffer = (uint64_t*)cxplat_reallocate(original_buffer, 8, 16);
+    uint64_t* new_buffer = (uint64_t*)cxplat_reallocate_with_tag(original_buffer, 8, 16, TEST_TAG);
     REQUIRE(new_buffer != nullptr);
     REQUIRE((((uintptr_t)new_buffer) % 64) == 0);
     REQUIRE(new_buffer[1] == 0);

--- a/cxplat/cxplat_test/cxplat_memory_test.cpp
+++ b/cxplat/cxplat_test/cxplat_memory_test.cpp
@@ -35,7 +35,7 @@ TEST_CASE("allocate", "[memory]")
     *buffer = 42;
 
     // Try a free with an unknown tag.
-    cxplat_free(buffer, CXPLAT_TAG_ANY);
+    cxplat_free_any_tag(buffer);
 }
 
 TEST_CASE("reallocate unaligned", "[memory]")

--- a/cxplat/cxplat_test/cxplat_memory_test.cpp
+++ b/cxplat/cxplat_test/cxplat_memory_test.cpp
@@ -14,57 +14,58 @@
 TEST_CASE("allocate", "[memory]")
 {
     // Try an allocation that need not be cache aligned.
-    uint64_t* buffer = (uint64_t*)cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, 8, TEST_TAG, false);
+    uint64_t* buffer = (uint64_t*)cxplat_allocate(CxPlatNonPagedPoolNx, 8, TEST_TAG, false);
     REQUIRE(buffer != nullptr);
     REQUIRE(*buffer != 0);
     *buffer = 0;
-    cxplat_free(buffer);
+    cxplat_free(buffer, TEST_TAG);
 
     // Try an allocation that must be cache aligned.
-    buffer = (uint64_t*)cxplat_allocate_with_tag(CxPlatNonPagedPoolNxCacheAligned, 8, TEST_TAG, false);
+    buffer = (uint64_t*)cxplat_allocate(CxPlatNonPagedPoolNxCacheAligned, 8, TEST_TAG, false);
     REQUIRE(buffer != nullptr);
     REQUIRE(*buffer != 0);
     REQUIRE((((uintptr_t)buffer) % 64) == 0);
     *buffer = 0;
-    cxplat_free(buffer);
+    cxplat_free(buffer, TEST_TAG);
 
     // Try an allocation that must be initialized.
-    buffer = (uint64_t*)cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, 8, TEST_TAG, true);
+    buffer = (uint64_t*)cxplat_allocate(CxPlatNonPagedPoolNx, 8, TEST_TAG, true);
     REQUIRE(buffer != nullptr);
     REQUIRE(*buffer == 0);
     *buffer = 42;
-    cxplat_free(buffer);
+
+    // Try a free with an unknown tag.
+    cxplat_free(buffer, CXPLAT_TAG_ANY);
 }
 
 TEST_CASE("reallocate unaligned", "[memory]")
 {
     // Try an allocation that need not be cache aligned.
-    uint64_t* original_buffer = (uint64_t*)cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, 8, TEST_TAG, true);
+    uint64_t* original_buffer = (uint64_t*)cxplat_allocate(CxPlatNonPagedPoolNx, 8, TEST_TAG, true);
     REQUIRE(original_buffer != nullptr);
 
-    uint64_t* new_buffer = (uint64_t*)cxplat_reallocate_with_tag(original_buffer, 8, 16, TEST_TAG);
+    uint64_t* new_buffer = (uint64_t*)cxplat_reallocate(original_buffer, 8, 16, TEST_TAG);
     REQUIRE(new_buffer != nullptr);
     REQUIRE(new_buffer[1] == 0);
 
-    cxplat_free(new_buffer);
+    cxplat_free(new_buffer, TEST_TAG);
 }
 
 TEST_CASE("reallocate aligned", "[memory]")
 {
     // Try an allocation that must be cache aligned.
-    uint64_t* original_buffer =
-        (uint64_t*)cxplat_allocate_with_tag(CxPlatNonPagedPoolNxCacheAligned, 8, TEST_TAG, true);
+    uint64_t* original_buffer = (uint64_t*)cxplat_allocate(CxPlatNonPagedPoolNxCacheAligned, 8, TEST_TAG, true);
     REQUIRE(original_buffer != nullptr);
 
-    uint64_t* new_buffer = (uint64_t*)cxplat_reallocate_with_tag(original_buffer, 8, 16, TEST_TAG);
+    uint64_t* new_buffer = (uint64_t*)cxplat_reallocate(original_buffer, 8, 16, TEST_TAG);
     REQUIRE(new_buffer != nullptr);
     REQUIRE((((uintptr_t)new_buffer) % 64) == 0);
     REQUIRE(new_buffer[1] == 0);
 
-    cxplat_free(new_buffer);
+    cxplat_free(new_buffer, TEST_TAG);
 }
 
-TEST_CASE("cxplat_free null", "[memory]") { cxplat_free(nullptr); }
+TEST_CASE("cxplat_free null", "[memory]") { cxplat_free(nullptr, TEST_TAG); }
 
 TEST_CASE("cxplat_duplicate_string", "[memory]")
 {
@@ -72,7 +73,7 @@ TEST_CASE("cxplat_duplicate_string", "[memory]")
     REQUIRE(string != nullptr);
     REQUIRE(strcmp(string, "test") == 0);
 
-    cxplat_free(string);
+    cxplat_free_string(string);
 }
 
 TEST_CASE("cxplat_duplicate_utf8_string", "[memory]")
@@ -87,5 +88,5 @@ TEST_CASE("cxplat_duplicate_utf8_string", "[memory]")
     REQUIRE(destination.length == source.length);
     REQUIRE(memcmp(destination.value, source.value, source.length) == 0);
 
-    cxplat_utf8_string_free(&destination);
+    cxplat_free_utf8_string(&destination);
 }

--- a/cxplat/inc/cxplat_memory.h
+++ b/cxplat/inc/cxplat_memory.h
@@ -59,18 +59,21 @@ __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(size) void*
 __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(new_size) void* cxplat_reallocate(
     _In_ _Post_invalid_ void* memory, size_t old_size, size_t new_size, uint32_t tag);
 
-// Pseudo-tag used with free API if the caller does not know the pool tag.
-// This is used for example by the usersim library to implement APIs such as
-// WdfObjectDelete() and ExFreePool().
-#define CXPLAT_TAG_ANY 0
-
 /**
  * @brief Free memory.
  * @param[in] memory Allocation to be freed.
- * @param[in] tag Pool tag to use, or CXPLAT_TAG_ANY if unknown.
+ * @param[in] tag Pool tag to use.
  */
 void
 cxplat_free(_Frees_ptr_opt_ void* memory, uint32_t tag);
+
+/**
+ * @brief Free memory.  This API should only be used when the caller does not
+ * know the correct pool tag.
+ * @param[in] memory Allocation to be freed.
+ */
+void
+cxplat_free_any_tag(_Frees_ptr_opt_ void* memory);
 
 /**
  * @brief Allocate memory that has a starting address that is cache aligned.

--- a/cxplat/inc/cxplat_memory.h
+++ b/cxplat/inc/cxplat_memory.h
@@ -45,42 +45,49 @@ typedef struct _cxplat_utf8_string
  * @param[in] initialize False to return "uninitialized" memory.
  * @returns Pointer to memory block allocated, or null on failure.
  */
-__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(size) void* cxplat_allocate_with_tag(
+__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(size) void* cxplat_allocate(
     _In_ cxplat_pool_type_t pool_type, size_t size, uint32_t tag, bool initialize);
 
 /**
- * @brief Reallocate memory with tag.
+ * @brief Reallocate memory.
  * @param[in] memory Allocation to be reallocated.
  * @param[in] old_size Old size of memory to reallocate.
  * @param[in] new_size New size of memory to reallocate.
  * @param[in] tag Pool tag to use.
  * @returns Pointer to memory block allocated, or null on failure.
  */
-__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(new_size) void* cxplat_reallocate_with_tag(
+__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(new_size) void* cxplat_reallocate(
     _In_ _Post_invalid_ void* memory, size_t old_size, size_t new_size, uint32_t tag);
+
+// Pseudo-tag used with free API if the caller does not know the pool tag.
+// This is used for example by the usersim library to implement APIs such as
+// WdfObjectDelete() and ExFreePool().
+#define CXPLAT_TAG_ANY 0
 
 /**
  * @brief Free memory.
  * @param[in] memory Allocation to be freed.
+ * @param[in] tag Pool tag to use, or CXPLAT_TAG_ANY if unknown.
  */
 void
-cxplat_free(_Frees_ptr_opt_ void* memory);
+cxplat_free(_Frees_ptr_opt_ void* memory, uint32_t tag);
 
 /**
- * @brief Allocate memory that has a starting address that is cache aligned with tag.
+ * @brief Allocate memory that has a starting address that is cache aligned.
  * @param[in] size Size of memory to allocate.
  * @param[in] tag Pool tag to use.
  * @returns Pointer to zero-initialized memory block allocated, or null on failure.
  */
 __drv_allocatesMem(Mem) _Must_inspect_result_
-    _Ret_writes_maybenull_(size) void* cxplat_allocate_cache_aligned_with_tag(size_t size, uint32_t tag);
+    _Ret_writes_maybenull_(size) void* cxplat_allocate_cache_aligned(size_t size, uint32_t tag);
 
 /**
  * @brief Free memory that has a starting address that is cache aligned.
  * @param[in] memory Allocation to be freed.
+ * @param[in] tag Pool tag to use.
  */
 void
-cxplat_free_cache_aligned(_Frees_ptr_opt_ void* memory);
+cxplat_free_cache_aligned(_Frees_ptr_opt_ void* memory, uint32_t tag);
 
 /**
  * @brief Allocate and copy a UTF-8 string.
@@ -101,7 +108,7 @@ cxplat_duplicate_utf8_string(_Out_ cxplat_utf8_string_t* destination, _In_ const
  * @param[in,out] string The string to free.
  */
 void
-cxplat_utf8_string_free(_Inout_ cxplat_utf8_string_t* string);
+cxplat_free_utf8_string(_Inout_ cxplat_utf8_string_t* string);
 
 /**
  * @brief Duplicate a null-terminated string.
@@ -111,5 +118,13 @@ cxplat_utf8_string_free(_Inout_ cxplat_utf8_string_t* string);
  */
 _Must_inspect_result_ _Ret_maybenull_z_ char*
 cxplat_duplicate_string(_In_z_ const char* source);
+
+/**
+ * @brief Free a null-terminated string allocated by cxplat_duplicate_string.
+ *
+ * @param[in,out] string The string to free.
+ */
+void
+cxplat_free_string(_Frees_ptr_opt_ _In_z_ const char* string);
 
 CXPLAT_EXTERN_C_END

--- a/cxplat/inc/cxplat_memory.h
+++ b/cxplat/inc/cxplat_memory.h
@@ -38,7 +38,7 @@ typedef struct _cxplat_utf8_string
     }
 
 /**
- * @brief Allocate memory.
+ * @brief Allocate memory. cxplat_allocate_with_tag() should normally be used instead of this API.
  * @param[in] size Size of memory to allocate.
  * @returns Pointer to memory block allocated, or null on failure.
  */

--- a/cxplat/inc/cxplat_memory.h
+++ b/cxplat/inc/cxplat_memory.h
@@ -38,13 +38,6 @@ typedef struct _cxplat_utf8_string
     }
 
 /**
- * @brief Allocate memory. cxplat_allocate_with_tag() should normally be used instead of this API.
- * @param[in] size Size of memory to allocate.
- * @returns Pointer to memory block allocated, or null on failure.
- */
-__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(size) void* cxplat_allocate(size_t size);
-
-/**
  * @brief Allocate memory.
  * @param[in] pool_type Type of pool to use.
  * @param[in] size Size of memory to allocate.
@@ -54,16 +47,6 @@ __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(size) void*
  */
 __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(size) void* cxplat_allocate_with_tag(
     _In_ cxplat_pool_type_t pool_type, size_t size, uint32_t tag, bool initialize);
-
-/**
- * @brief Reallocate memory.
- * @param[in] memory Allocation to be reallocated.
- * @param[in] old_size Old size of memory to reallocate.
- * @param[in] new_size New size of memory to reallocate.
- * @returns Pointer to memory block allocated, or null on failure.
- */
-__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(new_size) void* cxplat_reallocate(
-    _In_ _Post_invalid_ void* memory, size_t old_size, size_t new_size);
 
 /**
  * @brief Reallocate memory with tag.
@@ -82,14 +65,6 @@ __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(new_size) v
  */
 void
 cxplat_free(_Frees_ptr_opt_ void* memory);
-
-/**
- * @brief Allocate memory that has a starting address that is cache aligned.
- * @param[in] size Size of memory to allocate
- * @returns Pointer to memory block allocated, or null on failure.
- */
-__drv_allocatesMem(Mem) _Must_inspect_result_
-    _Ret_writes_maybenull_(size) void* cxplat_allocate_cache_aligned(size_t size);
 
 /**
  * @brief Allocate memory that has a starting address that is cache aligned with tag.

--- a/cxplat/src/cxplat_winkernel/cxplat_winkernel.vcxproj
+++ b/cxplat/src/cxplat_winkernel/cxplat_winkernel.vcxproj
@@ -48,6 +48,7 @@
     <ClInclude Include="..\..\inc\cxplat_workitem.h" />
     <ClInclude Include="..\..\inc\winkernel\cxplat_platform.h" />
     <ClInclude Include="..\..\inc\winkernel\cxplat_winkernel.h" />
+    <ClInclude Include="..\tags.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1ebe3966-7dc4-49b4-b840-3d33d63415ec}</ProjectGuid>

--- a/cxplat/src/cxplat_winkernel/memory_winkernel.c
+++ b/cxplat/src/cxplat_winkernel/memory_winkernel.c
@@ -31,11 +31,15 @@ void
 cxplat_free(_Frees_ptr_opt_ void* pointer, uint32_t tag)
 {
     if (pointer != NULL) {
-        if (tag == CXPLAT_TAG_ANY) {
-            ExFreePool(pointer);
-        } else {
-            ExFreePoolWithTag(pointer, tag);
-        }
+        ExFreePoolWithTag(pointer, tag);
+    }
+}
+
+void
+cxplat_free_any_tag(_Frees_ptr_opt_ void* pointer)
+{
+    if (pointer != NULL) {
+        ExFreePool(pointer);
     }
 }
 

--- a/cxplat/src/cxplat_winkernel/memory_winkernel.c
+++ b/cxplat/src/cxplat_winkernel/memory_winkernel.c
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 #include "cxplat.h"
+
 #include <wdm.h>
 
-__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(size) void* cxplat_allocate_with_tag(
+__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(size) void* cxplat_allocate(
     _In_ cxplat_pool_type_t pool_type, size_t size, uint32_t tag, bool initialize)
 {
     void* memory = ExAllocatePoolUninitialized(pool_type, size, tag);
@@ -14,36 +15,38 @@ __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(size) void*
     return memory;
 }
 
-__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(new_size) void* cxplat_reallocate_with_tag(
+__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(new_size) void* cxplat_reallocate(
     _In_ _Post_invalid_ void* pointer, size_t old_size, size_t new_size, uint32_t tag)
 {
-    void* new_pointer = cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, new_size, tag, true);
+    void* new_pointer = cxplat_allocate(CxPlatNonPagedPoolNx, new_size, tag, true);
     if (!new_pointer) {
         return NULL;
     }
     memcpy(new_pointer, pointer, min(old_size, new_size));
-    cxplat_free(pointer);
+    cxplat_free(pointer, tag);
     return new_pointer;
 }
 
 void
-cxplat_free(_Frees_ptr_opt_ void* pointer)
+cxplat_free(_Frees_ptr_opt_ void* pointer, uint32_t tag)
 {
-    if (pointer != NULL)
-    {
-        ExFreePool(pointer);
+    if (pointer != NULL) {
+        if (tag == CXPLAT_TAG_ANY) {
+            ExFreePool(pointer);
+        } else {
+            ExFreePoolWithTag(pointer, tag);
+        }
     }
 }
 
-__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(size) void*
-cxplat_allocate_cache_aligned_with_tag(size_t size, uint32_t tag)
+__drv_allocatesMem(Mem) _Must_inspect_result_
+    _Ret_writes_maybenull_(size) void* cxplat_allocate_cache_aligned(size_t size, uint32_t tag)
 {
-    return cxplat_allocate_with_tag(CxPlatNonPagedPoolNxCacheAligned, size, tag, true);
+    return cxplat_allocate(CxPlatNonPagedPoolNxCacheAligned, size, tag, true);
 }
 
 void
-cxplat_free_cache_aligned(_Frees_ptr_opt_ void* memory)
+cxplat_free_cache_aligned(_Frees_ptr_opt_ void* memory, uint32_t tag)
 {
-    cxplat_free(memory);
+    cxplat_free(memory, tag);
 }
-

--- a/cxplat/src/cxplat_winkernel/workitem_winkernel.c
+++ b/cxplat/src/cxplat_winkernel/workitem_winkernel.c
@@ -36,7 +36,7 @@ cxplat_allocate_preemptible_work_item(
     cxplat_status_t result = CXPLAT_STATUS_SUCCESS;
 
     *work_item = cxplat_allocate_with_tag(
-        CxPlatNonPagedPoolNx, sizeof(cxplat_preemptible_work_item_t), CXPLAT_PREEMPTIBLE_WORK_ITEM_TAG, true);
+        CxPlatNonPagedPoolNx, sizeof(cxplat_preemptible_work_item_t), CXPLAT_TAG_PREEMPTIBLE_WORK_ITEM, true);
     if (*work_item == NULL) {
         result = CXPLAT_STATUS_NO_MEMORY;
         goto Done;

--- a/cxplat/src/cxplat_winkernel/workitem_winkernel.c
+++ b/cxplat/src/cxplat_winkernel/workitem_winkernel.c
@@ -35,7 +35,7 @@ cxplat_allocate_preemptible_work_item(
 {
     cxplat_status_t result = CXPLAT_STATUS_SUCCESS;
 
-    *work_item = cxplat_allocate_with_tag(
+    *work_item = cxplat_allocate(
         CxPlatNonPagedPoolNx, sizeof(cxplat_preemptible_work_item_t), CXPLAT_TAG_PREEMPTIBLE_WORK_ITEM, true);
     if (*work_item == NULL) {
         result = CXPLAT_STATUS_NO_MEMORY;
@@ -56,7 +56,7 @@ cxplat_allocate_preemptible_work_item(
 
 Done:
     if (result != CXPLAT_STATUS_SUCCESS) {
-        cxplat_free(*work_item);
+        cxplat_free(*work_item, CXPLAT_TAG_PREEMPTIBLE_WORK_ITEM);
         *work_item = NULL;
     }
     return result;
@@ -73,7 +73,7 @@ cxplat_free_preemptible_work_item(_Frees_ptr_opt_ cxplat_preemptible_work_item_t
 {
     if (work_item) {
         IoFreeWorkItem(work_item->io_work_item);
-        cxplat_free(work_item);
+        cxplat_free(work_item, CXPLAT_TAG_PREEMPTIBLE_WORK_ITEM);
     }
 }
 

--- a/cxplat/src/cxplat_winkernel/workitem_winkernel.c
+++ b/cxplat/src/cxplat_winkernel/workitem_winkernel.c
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
+#include "../tags.h"
 #include "cxplat.h"
+
 #include <wdm.h>
 
 typedef struct _cxplat_preemptible_work_item
@@ -33,7 +35,8 @@ cxplat_allocate_preemptible_work_item(
 {
     cxplat_status_t result = CXPLAT_STATUS_SUCCESS;
 
-    *work_item = cxplat_allocate(sizeof(cxplat_preemptible_work_item_t));
+    *work_item = cxplat_allocate_with_tag(
+        CxPlatNonPagedPoolNx, sizeof(cxplat_preemptible_work_item_t), CXPLAT_PREEMPTIBLE_WORK_ITEM_TAG, true);
     if (*work_item == NULL) {
         result = CXPLAT_STATUS_NO_MEMORY;
         goto Done;
@@ -41,7 +44,7 @@ cxplat_allocate_preemptible_work_item(
 
     // We don't need to call ExAcquireRundownProtection() because
     // IoAllocateWorkItem takes care of rundown protection internally,
-    // unlike ExInitializeWorkItem. 
+    // unlike ExInitializeWorkItem.
 
     (*work_item)->io_work_item = IoAllocateWorkItem(caller_context);
     if ((*work_item)->io_work_item == NULL) {
@@ -80,4 +83,3 @@ cxplat_wait_for_preemptible_work_items_complete()
     // We used IoAllocateWorkItem() above instead of doing rundown
     // protection ourselves, so we don't need to do anything here.
 }
-

--- a/cxplat/src/cxplat_winuser/cxplat_winuser.vcxproj
+++ b/cxplat/src/cxplat_winuser/cxplat_winuser.vcxproj
@@ -204,6 +204,7 @@
     <ClInclude Include="..\..\inc\cxplat_workitem.h" />
     <ClInclude Include="..\..\inc\winuser\cxplat_platform.h" />
     <ClInclude Include="..\..\inc\winuser\cxplat_winuser.h" />
+    <ClInclude Include="..\tags.h" />
     <ClInclude Include="leak_detector.h" />
     <ClInclude Include="symbol_decoder.h" />
     <ClInclude Include="winuser_internal.h" />

--- a/cxplat/src/cxplat_winuser/cxplat_winuser.vcxproj.filters
+++ b/cxplat/src/cxplat_winuser/cxplat_winuser.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClInclude Include="..\..\inc\cxplat_workitem.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\tags.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="fault_injection.cpp">

--- a/cxplat/src/cxplat_winuser/memory_winuser.cpp
+++ b/cxplat/src/cxplat_winuser/memory_winuser.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
+#include "../tags.h"
 #include "cxplat.h"
 #include "leak_detector.h"
 #if !defined(UNREFERENCED_PARAMETER)
@@ -24,7 +25,11 @@ extern "C" size_t cxplat_fuzzing_memory_limit = MAXSIZE_T;
 typedef struct
 {
     cxplat_pool_type_t pool_type;
-    uint32_t tag;
+    union
+    {
+        uint32_t tag;
+        char tag_string[4];
+    };
     size_t size;
 } cxplat_allocation_header_t;
 
@@ -63,7 +68,7 @@ _unaligned_pointer_from_memory_block(const void* memory)
     return ((uint8_t*)memory) + UNALIGNED_POINTER_OFFSET;
 }
 
-__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(size) void* cxplat_allocate_with_tag(
+__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(size) void* cxplat_allocate(
     _In_ cxplat_pool_type_t pool_type, size_t size, uint32_t tag, bool initialize)
 {
     CXPLAT_RUNTIME_ASSERT(size > 0);
@@ -120,7 +125,7 @@ __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(size) void*
     return memory;
 }
 
-__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(new_size) void* cxplat_reallocate_with_tag(
+__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(new_size) void* cxplat_reallocate(
     _In_ _Post_invalid_ void* pointer, size_t old_size, size_t new_size, uint32_t tag)
 {
     UNREFERENCED_PARAMETER(tag);
@@ -165,31 +170,27 @@ __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(new_size) v
 }
 
 void
-cxplat_free(_Frees_ptr_opt_ void* pointer)
+cxplat_free(_Frees_ptr_opt_ void* pointer, uint32_t tag)
 {
-    if (pointer == nullptr)
-    {
+    if (pointer == nullptr) {
         return;
     }
     if (_cxplat_leak_detector_ptr) {
         _cxplat_leak_detector_ptr->unregister_allocation(reinterpret_cast<uintptr_t>(pointer));
     }
     cxplat_allocation_header_t* header = _header_from_pointer(pointer);
-    if (header->pool_type == CxPlatNonPagedPoolNxCacheAligned)
-    {
+    CXPLAT_DEBUG_ASSERT((tag == CXPLAT_TAG_ANY) || (header->tag == tag));
+    if (header->pool_type == CxPlatNonPagedPoolNxCacheAligned) {
         uint8_t* memory_block = _memory_block_from_aligned_pointer(pointer);
         _aligned_free(memory_block);
-    }
-    else
-    {
+    } else {
         uint8_t* memory_block = _memory_block_from_unaligned_pointer(pointer);
         free(memory_block);
     }
 }
 
 __drv_allocatesMem(Mem) _Must_inspect_result_
-_Ret_writes_maybenull_(size) void*
-cxplat_allocate_cache_aligned_with_tag(size_t size, uint32_t tag)
+    _Ret_writes_maybenull_(size) void* cxplat_allocate_cache_aligned(size_t size, uint32_t tag)
 {
     UNREFERENCED_PARAMETER(tag);
 
@@ -206,10 +207,4 @@ cxplat_allocate_cache_aligned_with_tag(size_t size, uint32_t tag)
         memset(memory, 0, size);
     }
     return memory;
-}
-
-void
-cxplat_free_cache_aligned(_Frees_ptr_opt_ void* memory)
-{
-    _aligned_free(memory);
 }

--- a/cxplat/src/cxplat_winuser/winuser_internal.h
+++ b/cxplat/src/cxplat_winuser/winuser_internal.h
@@ -1,11 +1,14 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 #pragma once
+#include "../tags.h"
+
 #include <winerror.h>
 
 #define CXPLAT_STATUS_FROM_WIN32(code) ((cxplat_status_t)__HRESULT_FROM_WIN32(code))
 
-cxplat_status_t cxplat_winuser_initialize_thread_pool();
+cxplat_status_t
+cxplat_winuser_initialize_thread_pool();
 
 void
 cxplat_winuser_clean_up_thread_pool();

--- a/cxplat/src/cxplat_winuser/workitem_winuser.cpp
+++ b/cxplat/src/cxplat_winuser/workitem_winuser.cpp
@@ -44,7 +44,7 @@ cxplat_allocate_preemptible_work_item(
     cxplat_status_t result = CXPLAT_STATUS_SUCCESS;
 
     *work_item = (cxplat_preemptible_work_item_t*)cxplat_allocate_with_tag(
-        CxPlatNonPagedPoolNx, sizeof(cxplat_preemptible_work_item_t), CXPLAT_PREEMPTIBLE_WORK_ITEM_TAG, true);
+        CxPlatNonPagedPoolNx, sizeof(cxplat_preemptible_work_item_t), CXPLAT_TAG_PREEMPTIBLE_WORK_ITEM, true);
     if (*work_item == nullptr) {
         result = CXPLAT_STATUS_NO_MEMORY;
         goto Done;

--- a/cxplat/src/cxplat_winuser/workitem_winuser.cpp
+++ b/cxplat/src/cxplat_winuser/workitem_winuser.cpp
@@ -43,7 +43,7 @@ cxplat_allocate_preemptible_work_item(
     UNREFERENCED_PARAMETER(caller_context);
     cxplat_status_t result = CXPLAT_STATUS_SUCCESS;
 
-    *work_item = (cxplat_preemptible_work_item_t*)cxplat_allocate_with_tag(
+    *work_item = (cxplat_preemptible_work_item_t*)cxplat_allocate(
         CxPlatNonPagedPoolNx, sizeof(cxplat_preemptible_work_item_t), CXPLAT_TAG_PREEMPTIBLE_WORK_ITEM, true);
     if (*work_item == nullptr) {
         result = CXPLAT_STATUS_NO_MEMORY;
@@ -62,7 +62,7 @@ cxplat_allocate_preemptible_work_item(
 
 Done:
     if (result != CXPLAT_STATUS_SUCCESS) {
-        cxplat_free(*work_item);
+        cxplat_free(*work_item, CXPLAT_TAG_PREEMPTIBLE_WORK_ITEM);
         *work_item = nullptr;
     }
     return result;
@@ -85,7 +85,7 @@ cxplat_free_preemptible_work_item(_Frees_ptr_opt_ cxplat_preemptible_work_item_t
     }
 
     CloseThreadpoolWork(work_item->work);
-    cxplat_free(work_item);
+    cxplat_free(work_item, CXPLAT_TAG_PREEMPTIBLE_WORK_ITEM);
 }
 
 cxplat_status_t

--- a/cxplat/src/cxplat_winuser/workitem_winuser.cpp
+++ b/cxplat/src/cxplat_winuser/workitem_winuser.cpp
@@ -3,6 +3,7 @@
 
 #include "cxplat.h"
 #include "winuser_internal.h"
+
 #include <windows.h>
 
 // Thread pool related globals.
@@ -42,7 +43,8 @@ cxplat_allocate_preemptible_work_item(
     UNREFERENCED_PARAMETER(caller_context);
     cxplat_status_t result = CXPLAT_STATUS_SUCCESS;
 
-    *work_item = (cxplat_preemptible_work_item_t*)cxplat_allocate(sizeof(cxplat_preemptible_work_item_t));
+    *work_item = (cxplat_preemptible_work_item_t*)cxplat_allocate_with_tag(
+        CxPlatNonPagedPoolNx, sizeof(cxplat_preemptible_work_item_t), CXPLAT_PREEMPTIBLE_WORK_ITEM_TAG, true);
     if (*work_item == nullptr) {
         result = CXPLAT_STATUS_NO_MEMORY;
         goto Done;

--- a/cxplat/src/memory.c
+++ b/cxplat/src/memory.c
@@ -11,11 +11,17 @@ _Must_inspect_result_ _Ret_maybenull_z_ char*
 cxplat_duplicate_string(_In_z_ const char* source)
 {
     size_t size = strlen(source) + 1;
-    char* destination = (char*)cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, size, CXPLAT_TAG_STRING, true);
+    char* destination = (char*)cxplat_allocate(CxPlatNonPagedPoolNx, size, CXPLAT_TAG_STRING, true);
     if (destination) {
         memcpy(destination, source, size);
     }
     return destination;
+}
+
+void
+cxplat_free_string(_Frees_ptr_opt_ _In_z_ const char* source)
+{
+    cxplat_free((void*)source, CXPLAT_TAG_STRING);
 }
 
 _Must_inspect_result_ cxplat_status_t
@@ -27,7 +33,7 @@ cxplat_duplicate_utf8_string(_Out_ cxplat_utf8_string_t* destination, _In_ const
         return CXPLAT_STATUS_SUCCESS;
     } else {
         destination->value =
-            (uint8_t*)cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, source->length, CXPLAT_TAG_UTF8_STRING, true);
+            (uint8_t*)cxplat_allocate(CxPlatNonPagedPoolNx, source->length, CXPLAT_TAG_UTF8_STRING, true);
         if (!destination->value) {
             return CXPLAT_STATUS_NO_MEMORY;
         }
@@ -38,9 +44,9 @@ cxplat_duplicate_utf8_string(_Out_ cxplat_utf8_string_t* destination, _In_ const
 }
 
 void
-cxplat_utf8_string_free(_Inout_ cxplat_utf8_string_t* string)
+cxplat_free_utf8_string(_Inout_ cxplat_utf8_string_t* string)
 {
-    cxplat_free(string->value);
+    cxplat_free(string->value, CXPLAT_TAG_UTF8_STRING);
     string->value = NULL;
     string->length = 0;
 }

--- a/cxplat/src/memory.c
+++ b/cxplat/src/memory.c
@@ -11,7 +11,7 @@ _Must_inspect_result_ _Ret_maybenull_z_ char*
 cxplat_duplicate_string(_In_z_ const char* source)
 {
     size_t size = strlen(source) + 1;
-    char* destination = (char*)cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, size, CXPLAT_STRING_TAG, true);
+    char* destination = (char*)cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, size, CXPLAT_TAG_STRING, true);
     if (destination) {
         memcpy(destination, source, size);
     }
@@ -27,7 +27,7 @@ cxplat_duplicate_utf8_string(_Out_ cxplat_utf8_string_t* destination, _In_ const
         return CXPLAT_STATUS_SUCCESS;
     } else {
         destination->value =
-            (uint8_t*)cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, source->length, CXPLAT_UTF8_STRING_TAG, true);
+            (uint8_t*)cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, source->length, CXPLAT_TAG_UTF8_STRING, true);
         if (!destination->value) {
             return CXPLAT_STATUS_NO_MEMORY;
         }

--- a/cxplat/src/memory.c
+++ b/cxplat/src/memory.c
@@ -7,23 +7,6 @@
 #include <memory.h>
 #include <string.h>
 
-__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(size) void* cxplat_allocate(size_t size)
-{
-    return cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, size, CXPLAT_DEFAULT_TAG, true);
-}
-
-__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(new_size) void* cxplat_reallocate(
-    _In_ _Post_invalid_ void* memory, size_t old_size, size_t new_size)
-{
-    return cxplat_reallocate_with_tag(memory, old_size, new_size, CXPLAT_DEFAULT_TAG);
-}
-
-__drv_allocatesMem(Mem) _Must_inspect_result_
-    _Ret_writes_maybenull_(size) void* cxplat_allocate_cache_aligned(size_t size)
-{
-    return cxplat_allocate_cache_aligned_with_tag(size, CXPLAT_DEFAULT_TAG);
-}
-
 _Must_inspect_result_ _Ret_maybenull_z_ char*
 cxplat_duplicate_string(_In_z_ const char* source)
 {

--- a/cxplat/src/memory.c
+++ b/cxplat/src/memory.c
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 #include "cxplat.h"
+#include "tags.h"
+
 #include <memory.h>
 #include <string.h>
-
-#define CXPLAT_DEFAULT_TAG 'lpxc'
 
 __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(size) void* cxplat_allocate(size_t size)
 {
@@ -28,7 +28,7 @@ _Must_inspect_result_ _Ret_maybenull_z_ char*
 cxplat_duplicate_string(_In_z_ const char* source)
 {
     size_t size = strlen(source) + 1;
-    char* destination = (char*)cxplat_allocate(size);
+    char* destination = (char*)cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, size, CXPLAT_STRING_TAG, true);
     if (destination) {
         memcpy(destination, source, size);
     }
@@ -43,7 +43,8 @@ cxplat_duplicate_utf8_string(_Out_ cxplat_utf8_string_t* destination, _In_ const
         destination->length = 0;
         return CXPLAT_STATUS_SUCCESS;
     } else {
-        destination->value = (uint8_t*)cxplat_allocate(source->length);
+        destination->value =
+            (uint8_t*)cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, source->length, CXPLAT_UTF8_STRING_TAG, true);
         if (!destination->value) {
             return CXPLAT_STATUS_NO_MEMORY;
         }

--- a/cxplat/src/tags.h
+++ b/cxplat/src/tags.h
@@ -3,7 +3,6 @@
 #pragma once
 
 // Pool tags used by the cxplat library.
-#define CXPLAT_DEFAULT_TAG 'edxc'
 #define CXPLAT_PREEMPTIBLE_WORK_ITEM_TAG 'wpxc'
 #define CXPLAT_STRING_TAG 'tsxc'
 #define CXPLAT_UTF8_STRING_TAG 'suxc'

--- a/cxplat/src/tags.h
+++ b/cxplat/src/tags.h
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+#pragma once
+
+// Pool tags used by the cxplat library.
+#define CXPLAT_DEFAULT_TAG 'edxc'
+#define CXPLAT_PREEMPTIBLE_WORK_ITEM_TAG 'wpxc'
+#define CXPLAT_STRING_TAG 'tsxc'
+#define CXPLAT_UTF8_STRING_TAG 'suxc'

--- a/cxplat/src/tags.h
+++ b/cxplat/src/tags.h
@@ -3,6 +3,6 @@
 #pragma once
 
 // Pool tags used by the cxplat library.
-#define CXPLAT_PREEMPTIBLE_WORK_ITEM_TAG 'wpxc'
-#define CXPLAT_STRING_TAG 'tsxc'
-#define CXPLAT_UTF8_STRING_TAG 'suxc'
+#define CXPLAT_TAG_PREEMPTIBLE_WORK_ITEM 'wpxc'
+#define CXPLAT_TAG_STRING 'tsxc'
+#define CXPLAT_TAG_UTF8_STRING 'suxc'

--- a/inc/usersim/ex.h
+++ b/inc/usersim/ex.h
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
-#include "cxplat.h"
 #include "..\src\platform.h"
+#include "cxplat.h"
 #include "ke.h"
 
 #include <synchapi.h>
@@ -204,24 +204,5 @@ void
 usersim_initialize_ex(bool leak_detector);
 void
 usersim_clean_up_ex();
-
-#ifdef __cplusplus
-#include <memory>
-namespace usersim_helper {
-
-struct _usersim_free_functor
-{
-    void
-    operator()(void* memory)
-    {
-        cxplat_free(memory);
-    }
-};
-
-typedef std::unique_ptr<void, _usersim_free_functor> usersim_memory_ptr;
-
-} // namespace usersim_helper
-
-#endif
 
 #endif

--- a/src/etw.cpp
+++ b/src/etw.cpp
@@ -18,7 +18,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS EtwRegister(
     _In_opt_ PVOID callback_context,
     _Out_ PREGHANDLE reg_handle)
 {
-    usersim_etw_provider_t* provider = (usersim_etw_provider_t*)cxplat_allocate_with_tag(
+    usersim_etw_provider_t* provider = (usersim_etw_provider_t*)cxplat_allocate(
         CxPlatNonPagedPoolNx, sizeof(*provider), USERSIM_TAG_ETW_PROVIDER, true);
     if (provider == nullptr) {
         return STATUS_NO_MEMORY;
@@ -32,7 +32,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS EtwRegister(
 
 _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS EtwUnregister(_In_ REGHANDLE reg_handle)
 {
-    cxplat_free((void*)(uintptr_t)reg_handle);
+    cxplat_free((void*)(uintptr_t)reg_handle, USERSIM_TAG_ETW_PROVIDER);
     return STATUS_SUCCESS;
 }
 

--- a/src/etw.cpp
+++ b/src/etw.cpp
@@ -19,7 +19,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS EtwRegister(
     _Out_ PREGHANDLE reg_handle)
 {
     usersim_etw_provider_t* provider = (usersim_etw_provider_t*)cxplat_allocate_with_tag(
-        CxPlatNonPagedPoolNx, sizeof(*provider), USERSIM_ETW_PROVIDER_TAG, true);
+        CxPlatNonPagedPoolNx, sizeof(*provider), USERSIM_TAG_ETW_PROVIDER, true);
     if (provider == nullptr) {
         return STATUS_NO_MEMORY;
     }

--- a/src/etw.cpp
+++ b/src/etw.cpp
@@ -18,7 +18,8 @@ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS EtwRegister(
     _In_opt_ PVOID callback_context,
     _Out_ PREGHANDLE reg_handle)
 {
-    usersim_etw_provider_t* provider = (usersim_etw_provider_t*)cxplat_allocate(sizeof(*provider));
+    usersim_etw_provider_t* provider = (usersim_etw_provider_t*)cxplat_allocate_with_tag(
+        CxPlatNonPagedPoolNx, sizeof(*provider), USERSIM_ETW_PROVIDER_TAG, true);
     if (provider == nullptr) {
         return STATUS_NO_MEMORY;
     }

--- a/src/ex.cpp
+++ b/src/ex.cpp
@@ -155,7 +155,7 @@ ExFreePoolCPP(_Frees_ptr_ void* p)
     if (p == nullptr) {
         KeBugCheckExCPP(BAD_POOL_CALLER, 0x46, 0, 0, 0);
     }
-    cxplat_free(p, CXPLAT_TAG_ANY);
+    cxplat_free_any_tag(p);
 }
 
 void

--- a/src/ex.cpp
+++ b/src/ex.cpp
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #include "cxplat_fault_injection.h"
-#include "platform.h"
 #include "kernel_um.h"
+#include "platform.h"
 #include "usersim/ex.h"
 #include "usersim/ke.h"
 
@@ -117,16 +117,13 @@ _Releases_shared_lock_(spin_lock->lock) void ExReleaseSpinLockSharedEx(
     ReleaseSRWLockShared(&spin_lock->lock);
 }
 
- _Ret_maybenull_ void*
-ExAllocatePoolUninitializedCPP(
-    _In_ POOL_TYPE pool_type,
-    _In_ size_t number_of_bytes,
-    _In_ unsigned long tag)
+_Ret_maybenull_ void*
+ExAllocatePoolUninitializedCPP(_In_ POOL_TYPE pool_type, _In_ size_t number_of_bytes, _In_ unsigned long tag)
 {
     if (tag == 0) {
         KeBugCheckExCPP(BAD_POOL_CALLER, 0x9B, pool_type, number_of_bytes, 0);
     }
-    return cxplat_allocate_with_tag((cxplat_pool_type_t)pool_type, number_of_bytes, tag, false);
+    return cxplat_allocate((cxplat_pool_type_t)pool_type, number_of_bytes, tag, false);
 }
 
 _Ret_maybenull_ void*
@@ -138,14 +135,12 @@ ExAllocatePoolUninitialized(
 
 _Ret_maybenull_ void*
 ExAllocatePoolWithTagCPP(
-    _In_ __drv_strictTypeMatch(__drv_typeExpr) POOL_TYPE pool_type,
-    SIZE_T number_of_bytes,
-    ULONG tag)
+    _In_ __drv_strictTypeMatch(__drv_typeExpr) POOL_TYPE pool_type, SIZE_T number_of_bytes, ULONG tag)
 {
     if (tag == 0 || number_of_bytes == 0) {
         KeBugCheckExCPP(BAD_POOL_CALLER, 0x9B, pool_type, number_of_bytes, 0);
     }
-    return cxplat_allocate_with_tag((cxplat_pool_type_t)pool_type, number_of_bytes, tag, true);
+    return cxplat_allocate((cxplat_pool_type_t)pool_type, number_of_bytes, tag, true);
 }
 
 _Ret_maybenull_ void*
@@ -160,7 +155,7 @@ ExFreePoolCPP(_Frees_ptr_ void* p)
     if (p == nullptr) {
         KeBugCheckExCPP(BAD_POOL_CALLER, 0x46, 0, 0, 0);
     }
-    cxplat_free(p);
+    cxplat_free(p, CXPLAT_TAG_ANY);
 }
 
 void
@@ -172,11 +167,10 @@ ExFreePool(_Frees_ptr_ void* p)
 void
 ExFreePoolWithTagCPP(_Frees_ptr_ void* p, ULONG tag)
 {
-    UNREFERENCED_PARAMETER(tag);
     if (p == nullptr) {
         KeBugCheckExCPP(BAD_POOL_CALLER, 0x46, 0, 0, 0);
     }
-    cxplat_free(p);
+    cxplat_free(p, tag);
 }
 
 void

--- a/src/fwp_um.cpp
+++ b/src/fwp_um.cpp
@@ -43,7 +43,7 @@ void static _allocate_and_initialize_connection_request(
     ADDRESS_FAMILY family, _In_ const fwp_classify_parameters_t* parameters)
 {
     CXPLAT_DEBUG_ASSERT(_fwp_um_connect_request == nullptr);
-    _fwp_um_connect_request = (FWPS_CONNECT_REQUEST0*)cxplat_allocate_with_tag(
+    _fwp_um_connect_request = (FWPS_CONNECT_REQUEST0*)cxplat_allocate(
         CxPlatNonPagedPoolNx, sizeof(FWPS_CONNECT_REQUEST0), USERSIM_TAG_FWPS_CONNECT_REQUEST0, true);
     if (_fwp_um_connect_request == nullptr) {
         // Most likely we are under fault injection simulation. Return.
@@ -57,7 +57,7 @@ void static _allocate_and_initialize_connection_request(
 
 void static _free_connection_request()
 {
-    cxplat_free(_fwp_um_connect_request);
+    cxplat_free(_fwp_um_connect_request, USERSIM_TAG_FWPS_CONNECT_REQUEST0);
     _fwp_um_connect_request = nullptr;
 }
 
@@ -862,7 +862,7 @@ _IRQL_requires_(PASSIVE_LEVEL) NTSTATUS NTAPI
     UNREFERENCED_PARAMETER(flags);
 
     // Fault injection is implicitly introduced by cxplat_allocate_with_tag().
-    *redirectHandle = (HANDLE)cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, 1, USERSIM_TAG_HANDLE, true);
+    *redirectHandle = (HANDLE)cxplat_allocate(CxPlatNonPagedPoolNx, 1, USERSIM_TAG_HANDLE, true);
     if (*redirectHandle == nullptr) {
         return STATUS_NO_MEMORY;
     }
@@ -872,7 +872,7 @@ _IRQL_requires_(PASSIVE_LEVEL) NTSTATUS NTAPI
 
 _IRQL_requires_(PASSIVE_LEVEL) void NTAPI FwpsRedirectHandleDestroy0(_In_ HANDLE redirectHandle)
 {
-    cxplat_free(redirectHandle);
+    cxplat_free(redirectHandle, USERSIM_TAG_HANDLE);
 }
 
 _IRQL_requires_min_(PASSIVE_LEVEL) _IRQL_requires_max_(DISPATCH_LEVEL) FWPS_CONNECTION_REDIRECT_STATE NTAPI

--- a/src/fwp_um.cpp
+++ b/src/fwp_um.cpp
@@ -44,7 +44,7 @@ void static _allocate_and_initialize_connection_request(
 {
     CXPLAT_DEBUG_ASSERT(_fwp_um_connect_request == nullptr);
     _fwp_um_connect_request = (FWPS_CONNECT_REQUEST0*)cxplat_allocate_with_tag(
-        CxPlatNonPagedPoolNx, sizeof(FWPS_CONNECT_REQUEST0), USERSIM_FWPS_CONNECT_REQUEST0_TAG, true);
+        CxPlatNonPagedPoolNx, sizeof(FWPS_CONNECT_REQUEST0), USERSIM_TAG_FWPS_CONNECT_REQUEST0, true);
     if (_fwp_um_connect_request == nullptr) {
         // Most likely we are under fault injection simulation. Return.
         return;
@@ -862,7 +862,7 @@ _IRQL_requires_(PASSIVE_LEVEL) NTSTATUS NTAPI
     UNREFERENCED_PARAMETER(flags);
 
     // Fault injection is implicitly introduced by cxplat_allocate_with_tag().
-    *redirectHandle = (HANDLE)cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, 1, USERSIM_HANDLE_TAG, true);
+    *redirectHandle = (HANDLE)cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, 1, USERSIM_TAG_HANDLE, true);
     if (*redirectHandle == nullptr) {
         return STATUS_NO_MEMORY;
     }

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -45,7 +45,7 @@ IoAllocateMdl(
     UNREFERENCED_PARAMETER(charge_quota);
     UNREFERENCED_PARAMETER(irp);
 
-    mdl = reinterpret_cast<MDL*>(cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, sizeof(MDL), USERSIM_TAG_MDL, true));
+    mdl = reinterpret_cast<MDL*>(cxplat_allocate(CxPlatNonPagedPoolNx, sizeof(MDL), USERSIM_TAG_MDL, true));
     if (mdl == NULL) {
         return mdl;
     }
@@ -70,8 +70,8 @@ io_work_item_wrapper(_In_ cxplat_preemptible_work_item_t* work_item, _Inout_opt_
 PIO_WORKITEM
 IoAllocateWorkItem(_In_ DEVICE_OBJECT* device_object)
 {
-    auto io_work_item = (PIO_WORKITEM)cxplat_allocate_with_tag(
-        CxPlatNonPagedPoolNx, sizeof(IO_WORKITEM), USERSIM_TAG_IO_WORK_ITEM, true);
+    auto io_work_item =
+        (PIO_WORKITEM)cxplat_allocate(CxPlatNonPagedPoolNx, sizeof(IO_WORKITEM), USERSIM_TAG_IO_WORK_ITEM, true);
     if (!io_work_item) {
         return nullptr;
     }
@@ -79,7 +79,7 @@ IoAllocateWorkItem(_In_ DEVICE_OBJECT* device_object)
     cxplat_status_t status = cxplat_allocate_preemptible_work_item(
         nullptr, &io_work_item->cxplat_work_item, io_work_item_wrapper, io_work_item);
     if (!CXPLAT_SUCCEEDED(status)) {
-        cxplat_free(io_work_item);
+        cxplat_free(io_work_item, USERSIM_TAG_IO_WORK_ITEM);
         return nullptr;
     }
     return io_work_item;
@@ -102,13 +102,13 @@ void
 IoFreeWorkItem(_In_ __drv_freesMem(Mem) PIO_WORKITEM io_work_item)
 {
     cxplat_free_preemptible_work_item(io_work_item->cxplat_work_item);
-    cxplat_free(io_work_item);
+    cxplat_free(io_work_item, USERSIM_TAG_IO_WORK_ITEM);
 }
 
 void
 IoFreeMdl(MDL* mdl)
 {
-    cxplat_free(mdl);
+    cxplat_free(mdl, USERSIM_TAG_MDL);
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL) NTKERNELAPI PEPROCESS IoGetCurrentProcess(VOID)

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 #include "platform.h"
-#include "kernel_um.h"
 #include "usersim/ex.h"
 #include "usersim/io.h"
 
@@ -46,7 +45,7 @@ IoAllocateMdl(
     UNREFERENCED_PARAMETER(charge_quota);
     UNREFERENCED_PARAMETER(irp);
 
-    mdl = reinterpret_cast<MDL*>(cxplat_allocate(sizeof(MDL)));
+    mdl = reinterpret_cast<MDL*>(cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, sizeof(MDL), USERSIM_MDL_TAG, true));
     if (mdl == NULL) {
         return mdl;
     }
@@ -71,7 +70,8 @@ io_work_item_wrapper(_In_ cxplat_preemptible_work_item_t* work_item, _Inout_opt_
 PIO_WORKITEM
 IoAllocateWorkItem(_In_ DEVICE_OBJECT* device_object)
 {
-    auto io_work_item = (PIO_WORKITEM)cxplat_allocate(sizeof(IO_WORKITEM));
+    auto io_work_item = (PIO_WORKITEM)cxplat_allocate_with_tag(
+        CxPlatNonPagedPoolNx, sizeof(IO_WORKITEM), USERSIM_IO_WORK_ITEM_TAG, true);
     if (!io_work_item) {
         return nullptr;
     }
@@ -116,8 +116,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL) NTKERNELAPI PEPROCESS IoGetCurrentProcess(VO
     return (PEPROCESS)GetCurrentProcess();
 }
 
-_IRQL_requires_max_(DISPATCH_LEVEL) VOID
-IofCompleteRequest(_In_ PIRP irp, _In_ CCHAR priority_boost)
+_IRQL_requires_max_(DISPATCH_LEVEL) VOID IofCompleteRequest(_In_ PIRP irp, _In_ CCHAR priority_boost)
 {
     UNREFERENCED_PARAMETER(irp);
     UNREFERENCED_PARAMETER(priority_boost);

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -45,7 +45,7 @@ IoAllocateMdl(
     UNREFERENCED_PARAMETER(charge_quota);
     UNREFERENCED_PARAMETER(irp);
 
-    mdl = reinterpret_cast<MDL*>(cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, sizeof(MDL), USERSIM_MDL_TAG, true));
+    mdl = reinterpret_cast<MDL*>(cxplat_allocate_with_tag(CxPlatNonPagedPoolNx, sizeof(MDL), USERSIM_TAG_MDL, true));
     if (mdl == NULL) {
         return mdl;
     }
@@ -71,7 +71,7 @@ PIO_WORKITEM
 IoAllocateWorkItem(_In_ DEVICE_OBJECT* device_object)
 {
     auto io_work_item = (PIO_WORKITEM)cxplat_allocate_with_tag(
-        CxPlatNonPagedPoolNx, sizeof(IO_WORKITEM), USERSIM_IO_WORK_ITEM_TAG, true);
+        CxPlatNonPagedPoolNx, sizeof(IO_WORKITEM), USERSIM_TAG_IO_WORK_ITEM, true);
     if (!io_work_item) {
         return nullptr;
     }

--- a/src/platform.h
+++ b/src/platform.h
@@ -4,6 +4,7 @@
 
 #include "framework.h"
 #include "kernel_um.h"
+#include "tags.h"
 #include "usersim/common.h"
 
 typedef NTSTATUS usersim_result_t;

--- a/src/platform_user.cpp
+++ b/src/platform_user.cpp
@@ -164,8 +164,8 @@ usersim_allocate_ring_buffer_memory(size_t length)
         return nullptr;
     }
 
-    usersim_ring_descriptor_t* descriptor =
-        (usersim_ring_descriptor_t*)cxplat_allocate(sizeof(usersim_ring_descriptor_t));
+    usersim_ring_descriptor_t* descriptor = (usersim_ring_descriptor_t*)cxplat_allocate_with_tag(
+        CxPlatNonPagedPoolNx, sizeof(usersim_ring_descriptor_t), USERSIM_RING_DESCRIPTOR_TAG, true);
     if (!descriptor) {
         goto Exit;
     }
@@ -530,7 +530,8 @@ _IRQL_requires_max_(PASSIVE_LEVEL) _Must_inspect_result_ NTSTATUS
         return win32_error_to_usersim_error(GetLastError());
     }
 
-    privileges = (TOKEN_GROUPS_AND_PRIVILEGES*)cxplat_allocate(size);
+    privileges = (TOKEN_GROUPS_AND_PRIVILEGES*)cxplat_allocate_with_tag(
+        CxPlatNonPagedPoolNx, size, USERSIM_TOKEN_GROUPS_AND_PRIVILEGES_TAG, true);
     if (privileges == nullptr) {
         return STATUS_NO_MEMORY;
     }
@@ -578,7 +579,8 @@ usersim_utf8_string_to_unicode(_In_ const cxplat_utf8_string_t* input, _Outptr_ 
 
     result++;
 
-    unicode_string = (wchar_t*)cxplat_allocate(result * sizeof(wchar_t));
+    unicode_string = (wchar_t*)cxplat_allocate_with_tag(
+        CxPlatNonPagedPoolNx, result * sizeof(wchar_t), USERSIM_UNICODE_STRING_TAG, true);
     if (unicode_string == NULL) {
         retval = STATUS_NO_MEMORY;
         goto Done;

--- a/src/platform_user.cpp
+++ b/src/platform_user.cpp
@@ -164,7 +164,7 @@ usersim_allocate_ring_buffer_memory(size_t length)
         return nullptr;
     }
 
-    usersim_ring_descriptor_t* descriptor = (usersim_ring_descriptor_t*)cxplat_allocate_with_tag(
+    usersim_ring_descriptor_t* descriptor = (usersim_ring_descriptor_t*)cxplat_allocate(
         CxPlatNonPagedPoolNx, sizeof(usersim_ring_descriptor_t), USERSIM_TAG_RING_DESCRIPTOR, true);
     if (!descriptor) {
         goto Exit;
@@ -247,7 +247,7 @@ usersim_allocate_ring_buffer_memory(size_t length)
     view2 = nullptr;
 Exit:
     if (!result) {
-        cxplat_free(descriptor);
+        cxplat_free(descriptor, USERSIM_TAG_RING_DESCRIPTOR);
         descriptor = nullptr;
     }
 
@@ -281,7 +281,7 @@ usersim_free_ring_buffer_memory(_Frees_ptr_opt_ usersim_ring_descriptor_t* ring)
     if (ring) {
         UnmapViewOfFile(ring->primary_view);
         UnmapViewOfFile(ring->secondary_view);
-        cxplat_free(ring);
+        cxplat_free(ring, USERSIM_TAG_RING_DESCRIPTOR);
     }
     USERSIM_RETURN_VOID();
 }
@@ -530,7 +530,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL) _Must_inspect_result_ NTSTATUS
         return win32_error_to_usersim_error(GetLastError());
     }
 
-    privileges = (TOKEN_GROUPS_AND_PRIVILEGES*)cxplat_allocate_with_tag(
+    privileges = (TOKEN_GROUPS_AND_PRIVILEGES*)cxplat_allocate(
         CxPlatNonPagedPoolNx, size, USERSIM_TAG_TOKEN_GROUPS_AND_PRIVILEGES, true);
     if (privileges == nullptr) {
         return STATUS_NO_MEMORY;
@@ -547,7 +547,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL) _Must_inspect_result_ NTSTATUS
     *authentication_id = *(uint64_t*)&privileges->AuthenticationId;
 
 Exit:
-    cxplat_free(privileges);
+    cxplat_free(privileges, USERSIM_TAG_TOKEN_GROUPS_AND_PRIVILEGES);
     return return_value;
 }
 
@@ -579,8 +579,8 @@ usersim_utf8_string_to_unicode(_In_ const cxplat_utf8_string_t* input, _Outptr_ 
 
     result++;
 
-    unicode_string = (wchar_t*)cxplat_allocate_with_tag(
-        CxPlatNonPagedPoolNx, result * sizeof(wchar_t), USERSIM_TAG_UNICODE_STRING, true);
+    unicode_string =
+        (wchar_t*)cxplat_allocate(CxPlatNonPagedPoolNx, result * sizeof(wchar_t), USERSIM_TAG_UNICODE_STRING, true);
     if (unicode_string == NULL) {
         retval = STATUS_NO_MEMORY;
         goto Done;
@@ -598,7 +598,7 @@ usersim_utf8_string_to_unicode(_In_ const cxplat_utf8_string_t* input, _Outptr_ 
     retval = STATUS_SUCCESS;
 
 Done:
-    cxplat_free(unicode_string);
+    cxplat_free(unicode_string, USERSIM_TAG_UNICODE_STRING);
     return retval;
 }
 

--- a/src/platform_user.cpp
+++ b/src/platform_user.cpp
@@ -165,7 +165,7 @@ usersim_allocate_ring_buffer_memory(size_t length)
     }
 
     usersim_ring_descriptor_t* descriptor = (usersim_ring_descriptor_t*)cxplat_allocate_with_tag(
-        CxPlatNonPagedPoolNx, sizeof(usersim_ring_descriptor_t), USERSIM_RING_DESCRIPTOR_TAG, true);
+        CxPlatNonPagedPoolNx, sizeof(usersim_ring_descriptor_t), USERSIM_TAG_RING_DESCRIPTOR, true);
     if (!descriptor) {
         goto Exit;
     }
@@ -531,7 +531,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL) _Must_inspect_result_ NTSTATUS
     }
 
     privileges = (TOKEN_GROUPS_AND_PRIVILEGES*)cxplat_allocate_with_tag(
-        CxPlatNonPagedPoolNx, size, USERSIM_TOKEN_GROUPS_AND_PRIVILEGES_TAG, true);
+        CxPlatNonPagedPoolNx, size, USERSIM_TAG_TOKEN_GROUPS_AND_PRIVILEGES, true);
     if (privileges == nullptr) {
         return STATUS_NO_MEMORY;
     }
@@ -580,7 +580,7 @@ usersim_utf8_string_to_unicode(_In_ const cxplat_utf8_string_t* input, _Outptr_ 
     result++;
 
     unicode_string = (wchar_t*)cxplat_allocate_with_tag(
-        CxPlatNonPagedPoolNx, result * sizeof(wchar_t), USERSIM_UNICODE_STRING_TAG, true);
+        CxPlatNonPagedPoolNx, result * sizeof(wchar_t), USERSIM_TAG_UNICODE_STRING, true);
     if (unicode_string == NULL) {
         retval = STATUS_NO_MEMORY;
         goto Done;

--- a/src/se.cpp
+++ b/src/se.cpp
@@ -143,7 +143,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL) USERSIM_API BOOLEAN SeAccessCheck(
     }
 
     // Allocate buffer.
-    token_access_information = (TOKEN_ACCESS_INFORMATION*)cxplat_allocate_with_tag(
+    token_access_information = (TOKEN_ACCESS_INFORMATION*)cxplat_allocate(
         CxPlatNonPagedPoolNx, length, USERSIM_TAG_TOKEN_ACCESS_INFORMATION, true);
     if (token_access_information == nullptr) {
         *access_status = STATUS_NO_MEMORY;
@@ -163,7 +163,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL) USERSIM_API BOOLEAN SeAccessCheck(
         access_status);
 
 Done:
-    cxplat_free(token_access_information);
+    cxplat_free(token_access_information, USERSIM_TAG_TOKEN_ACCESS_INFORMATION);
     if (!subject_context_locked) {
         SeUnlockSubjectContext(subject_security_context);
     }

--- a/src/se.cpp
+++ b/src/se.cpp
@@ -144,7 +144,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL) USERSIM_API BOOLEAN SeAccessCheck(
 
     // Allocate buffer.
     token_access_information = (TOKEN_ACCESS_INFORMATION*)cxplat_allocate_with_tag(
-        CxPlatNonPagedPoolNx, length, USERSIM_TOKEN_ACCESS_INFORMATION_TAG, true);
+        CxPlatNonPagedPoolNx, length, USERSIM_TAG_TOKEN_ACCESS_INFORMATION, true);
     if (token_access_information == nullptr) {
         *access_status = STATUS_NO_MEMORY;
         goto Done;

--- a/src/se.cpp
+++ b/src/se.cpp
@@ -143,7 +143,8 @@ _IRQL_requires_max_(PASSIVE_LEVEL) USERSIM_API BOOLEAN SeAccessCheck(
     }
 
     // Allocate buffer.
-    token_access_information = (TOKEN_ACCESS_INFORMATION*)cxplat_allocate(length);
+    token_access_information = (TOKEN_ACCESS_INFORMATION*)cxplat_allocate_with_tag(
+        CxPlatNonPagedPoolNx, length, USERSIM_TOKEN_ACCESS_INFORMATION_TAG, true);
     if (token_access_information == nullptr) {
         *access_status = STATUS_NO_MEMORY;
         goto Done;

--- a/src/tags.h
+++ b/src/tags.h
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+#pragma once
+
+// Pool tags used by the usersim library.
+#define USERSIM_ETW_PROVIDER_TAG 'pesu'
+#define USERSIM_FWPS_CONNECT_REQUEST0_TAG 'cfsu'
+#define USERSIM_HANDLE_TAG 'ahsu'
+#define USERSIM_IO_WORK_ITEM_TAG 'wisu'
+#define USERSIM_MDL_TAG 'dmsu'
+#define USERSIM_RING_DESCRIPTOR_TAG 'drsu'
+#define USERSIM_TOKEN_ACCESS_INFORMATION_TAG 'atsu'
+#define USERSIM_TOKEN_GROUPS_AND_PRIVILEGES_TAG 'gtsu'
+#define USERSIM_UNICODE_STRING_TAG 'susu'
+#define USERSIM_WDF_DEVICE_INIT_TAG 'dwsu'

--- a/src/tags.h
+++ b/src/tags.h
@@ -3,13 +3,13 @@
 #pragma once
 
 // Pool tags used by the usersim library.
-#define USERSIM_ETW_PROVIDER_TAG 'pesu'
-#define USERSIM_FWPS_CONNECT_REQUEST0_TAG 'cfsu'
-#define USERSIM_HANDLE_TAG 'ahsu'
-#define USERSIM_IO_WORK_ITEM_TAG 'wisu'
-#define USERSIM_MDL_TAG 'dmsu'
-#define USERSIM_RING_DESCRIPTOR_TAG 'drsu'
-#define USERSIM_TOKEN_ACCESS_INFORMATION_TAG 'atsu'
-#define USERSIM_TOKEN_GROUPS_AND_PRIVILEGES_TAG 'gtsu'
-#define USERSIM_UNICODE_STRING_TAG 'susu'
-#define USERSIM_WDF_DEVICE_INIT_TAG 'dwsu'
+#define USERSIM_TAG_ETW_PROVIDER 'pesu'
+#define USERSIM_TAG_FWPS_CONNECT_REQUEST0 'cfsu'
+#define USERSIM_TAG_HANDLE 'ahsu'
+#define USERSIM_TAG_IO_WORK_ITEM 'wisu'
+#define USERSIM_TAG_MDL 'dmsu'
+#define USERSIM_TAG_RING_DESCRIPTOR 'drsu'
+#define USERSIM_TAG_TOKEN_ACCESS_INFORMATION 'atsu'
+#define USERSIM_TAG_TOKEN_GROUPS_AND_PRIVILEGES 'gtsu'
+#define USERSIM_TAG_UNICODE_STRING 'susu'
+#define USERSIM_TAG_WDF_DEVICE_INIT 'dwsu'

--- a/src/usersim.vcxproj
+++ b/src/usersim.vcxproj
@@ -237,6 +237,7 @@
     <ClInclude Include="..\inc\usersim\rtl.h" />
     <ClInclude Include="..\inc\usersim\se.h" />
     <ClInclude Include="platform.h" />
+    <ClInclude Include="tags.h" />
     <ClInclude Include="tracelog.h" />
   </ItemGroup>
   <ItemGroup>

--- a/src/usersim.vcxproj.filters
+++ b/src/usersim.vcxproj.filters
@@ -146,6 +146,9 @@
     <ClInclude Include="..\inc\usersim\zw.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="tags.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="Source.def">

--- a/src/wdf.cpp
+++ b/src/wdf.cpp
@@ -87,45 +87,34 @@ typedef struct _WDFDEVICE_INIT
     ULONG num_minor_functions[IRP_MJ_MAXIMUM_FUNCTION];
 } WDFDEVICE_INIT;
 
-static
-_Must_inspect_result_
-_IRQL_requires_max_(PASSIVE_LEVEL)
-PWDFDEVICE_INIT
-_WdfControlDeviceInitAllocate(
-    _In_ PWDF_DRIVER_GLOBALS driver_globals,
-    _In_ WDFDRIVER driver,
-    _In_ CONST UNICODE_STRING* sddl_string)
+static _Must_inspect_result_ _IRQL_requires_max_(PASSIVE_LEVEL) PWDFDEVICE_INIT _WdfControlDeviceInitAllocate(
+    _In_ PWDF_DRIVER_GLOBALS driver_globals, _In_ WDFDRIVER driver, _In_ CONST UNICODE_STRING* sddl_string)
 {
     UNREFERENCED_PARAMETER(driver_globals);
     UNREFERENCED_PARAMETER(driver);
     UNREFERENCED_PARAMETER(sddl_string);
 
-    PWDFDEVICE_INIT device_init = (PWDFDEVICE_INIT)cxplat_allocate(sizeof(*device_init));
+    PWDFDEVICE_INIT device_init = (PWDFDEVICE_INIT)cxplat_allocate_with_tag(
+        CxPlatNonPagedPoolNx, sizeof(*device_init), USERSIM_WDF_DEVICE_INIT_TAG, true);
     return device_init;
 }
 
 static _IRQL_requires_max_(DISPATCH_LEVEL) VOID
-_WdfDeviceInitFree(_In_ PWDF_DRIVER_GLOBALS driver_globals, _In_ PWDFDEVICE_INIT device_init)
+    _WdfDeviceInitFree(_In_ PWDF_DRIVER_GLOBALS driver_globals, _In_ PWDFDEVICE_INIT device_init)
 {
     UNREFERENCED_PARAMETER(driver_globals);
     cxplat_free(device_init);
 }
 
-static
-_IRQL_requires_max_(DISPATCH_LEVEL) VOID
-_WdfDeviceInitSetDeviceType(
-    _In_ PWDF_DRIVER_GLOBALS driver_globals, 
-    _In_ PWDFDEVICE_INIT device_init,
-    DEVICE_TYPE device_type)
+static _IRQL_requires_max_(DISPATCH_LEVEL) VOID _WdfDeviceInitSetDeviceType(
+    _In_ PWDF_DRIVER_GLOBALS driver_globals, _In_ PWDFDEVICE_INIT device_init, DEVICE_TYPE device_type)
 {
     UNREFERENCED_PARAMETER(driver_globals);
     device_init->device_type = device_type;
 }
 
-static
-_IRQL_requires_max_(DISPATCH_LEVEL) VOID
-_WdfDeviceInitSetCharacteristics(
-    _In_ PWDF_DRIVER_GLOBALS driver_globals, 
+static _IRQL_requires_max_(DISPATCH_LEVEL) VOID _WdfDeviceInitSetCharacteristics(
+    _In_ PWDF_DRIVER_GLOBALS driver_globals,
     _In_ PWDFDEVICE_INIT device_init,
     ULONG device_characteristics,
     BOOLEAN or_in_values)
@@ -137,13 +126,8 @@ _WdfDeviceInitSetCharacteristics(
     device_init->device_characteristics |= device_characteristics;
 }
 
-static _Must_inspect_result_
-_IRQL_requires_max_(PASSIVE_LEVEL)
-NTSTATUS
-_WdfDeviceInitAssignName(
-    _In_ PWDF_DRIVER_GLOBALS driver_globals,
-    _In_ PWDFDEVICE_INIT device_init,
-    _In_opt_ PCUNICODE_STRING device_name)
+static _Must_inspect_result_ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS _WdfDeviceInitAssignName(
+    _In_ PWDF_DRIVER_GLOBALS driver_globals, _In_ PWDFDEVICE_INIT device_init, _In_opt_ PCUNICODE_STRING device_name)
 {
     if (driver_globals != &g_UsersimWdfDriverGlobals) {
         return STATUS_INVALID_PARAMETER;
@@ -157,9 +141,7 @@ _WdfDeviceInitAssignName(
     return STATUS_SUCCESS;
 }
 
-static
-_IRQL_requires_max_(DISPATCH_LEVEL) VOID
-_WdfDeviceInitSetFileObjectConfig(
+static _IRQL_requires_max_(DISPATCH_LEVEL) VOID _WdfDeviceInitSetFileObjectConfig(
     _In_ PWDF_DRIVER_GLOBALS driver_globals,
     _In_ PWDFDEVICE_INIT device_init,
     _In_ PWDF_FILEOBJECT_CONFIG file_object_config,
@@ -170,10 +152,7 @@ _WdfDeviceInitSetFileObjectConfig(
     device_init->file_object_attributes = file_object_attributes;
 }
 
-static _Must_inspect_result_
-_IRQL_requires_max_(DISPATCH_LEVEL)
-NTSTATUS
-_WdfDeviceInitAssignWdmIrpPreprocessCallback(
+static _Must_inspect_result_ _IRQL_requires_max_(DISPATCH_LEVEL) NTSTATUS _WdfDeviceInitAssignWdmIrpPreprocessCallback(
     _In_ PWDF_DRIVER_GLOBALS driver_globals,
     _In_ PWDFDEVICE_INIT device_init,
     _In_ PFN_WDFDEVICE_WDM_IRP_PREPROCESS evt_device_wdm_irp_preprocess,
@@ -201,13 +180,8 @@ _WdfDeviceInitAssignWdmIrpPreprocessCallback(
     return STATUS_SUCCESS;
 }
 
-static _Must_inspect_result_
-_IRQL_requires_max_(PASSIVE_LEVEL)
-NTSTATUS
-_WdfDeviceCreateSymbolicLink(
-    _In_ PWDF_DRIVER_GLOBALS driver_globals,
-    _In_ WDFDEVICE device,
-    _In_ PCUNICODE_STRING symbolic_link_name)
+static _Must_inspect_result_ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS _WdfDeviceCreateSymbolicLink(
+    _In_ PWDF_DRIVER_GLOBALS driver_globals, _In_ WDFDEVICE device, _In_ PCUNICODE_STRING symbolic_link_name)
 {
     UNREFERENCED_PARAMETER(device);
     UNREFERENCED_PARAMETER(symbolic_link_name);
@@ -221,11 +195,7 @@ _WdfDeviceCreateSymbolicLink(
     return STATUS_SUCCESS;
 }
 
-static
-_Must_inspect_result_
-_IRQL_requires_max_(DISPATCH_LEVEL)
-NTSTATUS
-_WdfIoQueueCreate(
+static _Must_inspect_result_ _IRQL_requires_max_(DISPATCH_LEVEL) NTSTATUS _WdfIoQueueCreate(
     _In_ PWDF_DRIVER_GLOBALS driver_globals,
     _In_ WDFDEVICE device,
     _In_ PWDF_IO_QUEUE_CONFIG config,
@@ -249,21 +219,21 @@ _WdfIoQueueCreate(
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL) VOID
-_WdfControlFinishInitializing(_In_ PWDF_DRIVER_GLOBALS driver_globals, _In_ WDFDEVICE device)
+    _WdfControlFinishInitializing(_In_ PWDF_DRIVER_GLOBALS driver_globals, _In_ WDFDEVICE device)
 {
     UNREFERENCED_PARAMETER(driver_globals);
     UNREFERENCED_PARAMETER(device);
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL) PDEVICE_OBJECT
-_WdfDeviceWdmGetDeviceObject(_In_ PWDF_DRIVER_GLOBALS driver_globals, _In_ WDFDEVICE device)
+    _WdfDeviceWdmGetDeviceObject(_In_ PWDF_DRIVER_GLOBALS driver_globals, _In_ WDFDEVICE device)
 {
     UNREFERENCED_PARAMETER(driver_globals);
     return (PDEVICE_OBJECT)device;
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL) VOID
-_WdfObjectDelete(_In_ PWDF_DRIVER_GLOBALS driver_globals, _In_ WDFOBJECT object)
+    _WdfObjectDelete(_In_ PWDF_DRIVER_GLOBALS driver_globals, _In_ WDFOBJECT object)
 {
     UNREFERENCED_PARAMETER(driver_globals);
 

--- a/src/wdf.cpp
+++ b/src/wdf.cpp
@@ -94,8 +94,8 @@ static _Must_inspect_result_ _IRQL_requires_max_(PASSIVE_LEVEL) PWDFDEVICE_INIT 
     UNREFERENCED_PARAMETER(driver);
     UNREFERENCED_PARAMETER(sddl_string);
 
-    PWDFDEVICE_INIT device_init = (PWDFDEVICE_INIT)cxplat_allocate_with_tag(
-        CxPlatNonPagedPoolNx, sizeof(*device_init), USERSIM_TAG_WDF_DEVICE_INIT, true);
+    PWDFDEVICE_INIT device_init =
+        (PWDFDEVICE_INIT)cxplat_allocate(CxPlatNonPagedPoolNx, sizeof(*device_init), USERSIM_TAG_WDF_DEVICE_INIT, true);
     return device_init;
 }
 
@@ -103,7 +103,7 @@ static _IRQL_requires_max_(DISPATCH_LEVEL) VOID
     _WdfDeviceInitFree(_In_ PWDF_DRIVER_GLOBALS driver_globals, _In_ PWDFDEVICE_INIT device_init)
 {
     UNREFERENCED_PARAMETER(driver_globals);
-    cxplat_free(device_init);
+    cxplat_free(device_init, USERSIM_TAG_WDF_DEVICE_INIT);
 }
 
 static _IRQL_requires_max_(DISPATCH_LEVEL) VOID _WdfDeviceInitSetDeviceType(
@@ -237,7 +237,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL) VOID
 {
     UNREFERENCED_PARAMETER(driver_globals);
 
-    cxplat_free(object);
+    cxplat_free(object, CXPLAT_TAG_ANY);
 }
 
 WDFFUNC g_UsersimWdfFunctions[WdfFunctionTableNumEntries];

--- a/src/wdf.cpp
+++ b/src/wdf.cpp
@@ -237,7 +237,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL) VOID
 {
     UNREFERENCED_PARAMETER(driver_globals);
 
-    cxplat_free(object, CXPLAT_TAG_ANY);
+    cxplat_free_any_tag(object);
 }
 
 WDFFUNC g_UsersimWdfFunctions[WdfFunctionTableNumEntries];

--- a/src/wdf.cpp
+++ b/src/wdf.cpp
@@ -95,7 +95,7 @@ static _Must_inspect_result_ _IRQL_requires_max_(PASSIVE_LEVEL) PWDFDEVICE_INIT 
     UNREFERENCED_PARAMETER(sddl_string);
 
     PWDFDEVICE_INIT device_init = (PWDFDEVICE_INIT)cxplat_allocate_with_tag(
-        CxPlatNonPagedPoolNx, sizeof(*device_init), USERSIM_WDF_DEVICE_INIT_TAG, true);
+        CxPlatNonPagedPoolNx, sizeof(*device_init), USERSIM_TAG_WDF_DEVICE_INIT, true);
     return device_init;
 }
 


### PR DESCRIPTION
* Remove non-tag-based allocation APIs
* Add `cxplat_free_any_tag()` which is required by some callers
* Rename `cxplat_utf8_string_free()` to `cxplat_free_utf8_string()` for consistency with other APIs
* Add `cxplat_free_string()` to match `cxplat_duplicate_string()`

Any whitespace changes come from the format-code utility.

Fixes #97