### PR TITLE
Restrict fault injection to requested modules 

### DIFF
--- a/cxplat/cxplat_test/cxplat_fault_injection.cpp
+++ b/cxplat/cxplat_test/cxplat_fault_injection.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#if !defined(CMAKE_NUGET)
+#include <catch2/catch_all.hpp>
+#else
+#include <catch2/catch.hpp>
+#endif
+
+#include "cxplat_fault_injection.h"
+
+struct _on_exit
+{
+    std::function<void()> _func;
+    _on_exit(std::function<void()> func) : _func(func) {}
+    ~_on_exit() { _func(); }
+};
+
+enum class _fault_injection_test_state
+{
+    ExpectedInjectFault,               /// < Fault should be injected.
+    ExpectedNotInjectFault,            /// < Fault should not be injected.
+    ExpectetNotInjectFaultAfterReload, /// < Fault should not be injected after reloading.
+    ExpectedInjectFaultAfterReset,     /// < Fault should be injected after reset.
+    ExpectedInjectDifferentCallsite,   /// < Fault should be injected at a different callsite.
+};
+
+TEST_CASE("fault_injection", "[fault_injection]")
+{
+    bool fault_injection_enabled = false;
+    // Verify it's disabled by default.
+    REQUIRE(cxplat_fault_injection_is_enabled() == false);
+
+    // Verify it's enabled when initialized.
+    REQUIRE(cxplat_fault_injection_initialize(0, nullptr) == CXPLAT_STATUS_SUCCESS);
+    fault_injection_enabled = true;
+
+    _on_exit _([&]() {
+        if (fault_injection_enabled) {
+            cxplat_fault_injection_uninitialize();
+        }
+    });
+    REQUIRE(cxplat_fault_injection_is_enabled() == true);
+
+    // Clear the fault injection state.
+    cxplat_fault_injection_reset();
+
+    for (_fault_injection_test_state state = _fault_injection_test_state::ExpectedInjectFault;
+         state <= _fault_injection_test_state::ExpectedInjectFaultAfterReset;
+         state = (_fault_injection_test_state)((int)state + 1)) {
+        bool fault_expected;
+        switch (state) {
+        case _fault_injection_test_state::ExpectedInjectFault:
+            fault_expected = true;
+            break;
+        case _fault_injection_test_state::ExpectedInjectFaultAfterReset:
+            cxplat_fault_injection_reset();
+            fault_expected = true;
+            break;
+        case _fault_injection_test_state::ExpectedNotInjectFault:
+            fault_expected = false;
+            break;
+        case _fault_injection_test_state::ExpectetNotInjectFaultAfterReload:
+            cxplat_fault_injection_uninitialize();
+            fault_injection_enabled = false;
+            REQUIRE(cxplat_fault_injection_initialize(0, nullptr) == CXPLAT_STATUS_SUCCESS);
+            fault_injection_enabled = true;
+            fault_expected = false;
+            break;
+        case _fault_injection_test_state::ExpectedInjectDifferentCallsite:
+            fault_expected = true;
+            REQUIRE(cxplat_fault_injection_inject_fault() == true);
+            break;
+        }
+        REQUIRE(cxplat_fault_injection_inject_fault() == fault_expected);
+    }
+}

--- a/cxplat/cxplat_test/cxplat_fault_injection_test.cpp
+++ b/cxplat/cxplat_test/cxplat_fault_injection_test.cpp
@@ -7,10 +7,9 @@
 #include <catch2/catch.hpp>
 #endif
 
-#include <windows.h>
-
 #include "cxplat_fault_injection.h"
 
+#include <windows.h>
 
 struct _on_exit
 {
@@ -21,11 +20,11 @@ struct _on_exit
 
 enum class _fault_injection_test_state
 {
-    ExpectedFault,               /// < Fault should be injected.
-    DontExpectedFault,            /// < Fault should not be injected.
-    DontExpectedFaultAfterReload, /// < Fault should not be injected after reloading.
-    ExpectedFaultAfterReset,     /// < Fault should be injected after reset.
-    ExpectedFaultDifferentCallsite,   /// < Fault should be injected at a different callsite.
+    ExpectedFault,                  /// < Fault should be injected.
+    DontExpectedFault,              /// < Fault should not be injected.
+    DontExpectedFaultAfterReload,   /// < Fault should not be injected after reloading.
+    ExpectedFaultAfterReset,        /// < Fault should be injected after reset.
+    ExpectedFaultDifferentCallsite, /// < Fault should be injected at a different callsite.
 };
 
 TEST_CASE("fault_injection", "[fault_injection]")
@@ -59,7 +58,7 @@ TEST_CASE("fault_injection", "[fault_injection]")
             fault_expected = true;
             break;
         case _fault_injection_test_state::DontExpectedFault:
-            fault_expected  = false;
+            fault_expected = false;
             break;
         case _fault_injection_test_state::DontExpectedFaultAfterReload:
             cxplat_fault_injection_uninitialize();

--- a/cxplat/cxplat_test/cxplat_fault_injection_test.cpp
+++ b/cxplat/cxplat_test/cxplat_fault_injection_test.cpp
@@ -18,13 +18,28 @@ struct _on_exit
     ~_on_exit() { _func(); }
 };
 
-enum class _fault_injection_test_state
+/// @brief  Enumerates the expected outcomes of fault injection tests.
+// The test will cycle through and perform the following actions:
+// 1. ExpectFault: Fault should be expected. This is the initial state, with no prior calls to
+//    cxplat_fault_injection_inject_fault(). It should return true.
+// 2. DontExpectFault: Fault should not be expected. This the second state, with one prior call to
+//    cxplat_fault_injection_inject_fault(). It should return false.
+// 3. DontExpectFaultAfterReload: Fault should not be expected. This is the third state, with some number of
+//    prior calls to cxplat_fault_injection_inject_fault() followed by a call to cxplat_fault_injection_uninitialize()
+//    and cxplat_fault_injection_initialize(). It should return false as the state is persisted across reloads.
+// 4. ExpectFaultAfterReset: Fault should be expected. This is the fourth state, with some number of prior calls to
+//    cxplat_fault_injection_inject_fault() followed by a call to cxplat_fault_injection_reset(). It should return true
+//    as the state is reset.
+// 5. ExpectFaultDifferentCallsite: Fault should be expected. This is the fifth state, with the state reset and a call
+//    to cxplat_fault_injection_inject_fault() at a different callsite. It should return true as the callsite is
+//    different.
+enum class _fault_injection_expected_outcome
 {
-    ExpectedFault,                  /// < Fault should be injected.
-    DontExpectedFault,              /// < Fault should not be injected.
-    DontExpectedFaultAfterReload,   /// < Fault should not be injected after reloading.
-    ExpectedFaultAfterReset,        /// < Fault should be injected after reset.
-    ExpectedFaultDifferentCallsite, /// < Fault should be injected at a different callsite.
+    ExpectFault,                  /// < Fault should be expected.
+    DontExpectFault,              /// < Fault should not be expected.
+    DontExpectFaultAfterReload,   /// < Fault should not be expected after reloading.
+    ExpectFaultAfterReset,        /// < Fault should be expected after reset.
+    ExpectFaultDifferentCallsite, /// < Fault should be expected at a different callsite.
 };
 
 TEST_CASE("fault_injection", "[fault_injection]")
@@ -49,18 +64,18 @@ TEST_CASE("fault_injection", "[fault_injection]")
     // Clear the fault injection state.
     cxplat_fault_injection_reset();
 
-    for (_fault_injection_test_state state = _fault_injection_test_state::ExpectedFault;
-         state <= _fault_injection_test_state::ExpectedFaultDifferentCallsite;
-         state = (_fault_injection_test_state)((int)state + 1)) {
+    for (_fault_injection_expected_outcome state = _fault_injection_expected_outcome::ExpectFault;
+         state <= _fault_injection_expected_outcome::ExpectFaultDifferentCallsite;
+         state = (_fault_injection_expected_outcome)((int)state + 1)) {
         bool fault_expected;
         switch (state) {
-        case _fault_injection_test_state::ExpectedFault:
+        case _fault_injection_expected_outcome::ExpectFault:
             fault_expected = true;
             break;
-        case _fault_injection_test_state::DontExpectedFault:
+        case _fault_injection_expected_outcome::DontExpectFault:
             fault_expected = false;
             break;
-        case _fault_injection_test_state::DontExpectedFaultAfterReload:
+        case _fault_injection_expected_outcome::DontExpectFaultAfterReload:
             cxplat_fault_injection_uninitialize();
             fault_injection_enabled = false;
             REQUIRE(cxplat_fault_injection_initialize(0) == CXPLAT_STATUS_SUCCESS);
@@ -68,11 +83,11 @@ TEST_CASE("fault_injection", "[fault_injection]")
             fault_injection_enabled = true;
             fault_expected = false;
             break;
-        case _fault_injection_test_state::ExpectedFaultAfterReset:
+        case _fault_injection_expected_outcome::ExpectFaultAfterReset:
             cxplat_fault_injection_reset();
             fault_expected = true;
             break;
-        case _fault_injection_test_state::ExpectedFaultDifferentCallsite:
+        case _fault_injection_expected_outcome::ExpectFaultDifferentCallsite:
             cxplat_fault_injection_reset();
             fault_expected = true;
             REQUIRE(cxplat_fault_injection_inject_fault() == true);

--- a/cxplat/cxplat_test/cxplat_fault_injection_test.cpp
+++ b/cxplat/cxplat_test/cxplat_fault_injection_test.cpp
@@ -52,14 +52,22 @@ TEST_CASE("fault_injection", "[fault_injection]")
     REQUIRE(cxplat_fault_injection_initialize(0) == CXPLAT_STATUS_SUCCESS);
     fault_injection_enabled = true;
 
+    REQUIRE(cxplat_fault_injection_is_enabled() == true);
+
+    // Verify that calling initialize again fails.
+    REQUIRE(cxplat_fault_injection_initialize(0) == CXPLAT_STATUS_INVALID_STATE);
+
+    // Verify that adding a module succeeds.
     REQUIRE(cxplat_fault_injection_add_module(GetModuleHandle(nullptr)) == CXPLAT_STATUS_SUCCESS);
+
+    // Verify that adding a module again fails.
+    REQUIRE(cxplat_fault_injection_add_module(GetModuleHandle(nullptr)) == CXPLAT_STATUS_INVALID_STATE);
 
     _on_exit _([&]() {
         if (fault_injection_enabled) {
             cxplat_fault_injection_uninitialize();
         }
     });
-    REQUIRE(cxplat_fault_injection_is_enabled() == true);
 
     // Clear the fault injection state.
     cxplat_fault_injection_reset();
@@ -95,4 +103,10 @@ TEST_CASE("fault_injection", "[fault_injection]")
         }
         REQUIRE(cxplat_fault_injection_inject_fault() == fault_expected);
     }
+
+    // Verify that removing a module succeeds.
+    REQUIRE(cxplat_fault_injection_remove_module(GetModuleHandle(nullptr)) == CXPLAT_STATUS_SUCCESS);
+
+    // Verify that removing a module again fails.
+    REQUIRE(cxplat_fault_injection_remove_module(GetModuleHandle(nullptr)) == CXPLAT_STATUS_INVALID_STATE);
 }

--- a/cxplat/cxplat_test/cxplat_test.vcxproj
+++ b/cxplat/cxplat_test/cxplat_test.vcxproj
@@ -132,6 +132,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="cxplat_fault_injection.cpp" />
     <ClCompile Include="cxplat_initialization_test.cpp" />
     <ClCompile Include="cxplat_memory_test.cpp" />
     <ClCompile Include="cxplat_rundown_test.cpp" />

--- a/cxplat/cxplat_test/cxplat_test.vcxproj
+++ b/cxplat/cxplat_test/cxplat_test.vcxproj
@@ -132,7 +132,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="cxplat_fault_injection.cpp" />
+    <ClCompile Include="cxplat_fault_injection_test.cpp" />
     <ClCompile Include="cxplat_initialization_test.cpp" />
     <ClCompile Include="cxplat_memory_test.cpp" />
     <ClCompile Include="cxplat_rundown_test.cpp" />

--- a/cxplat/cxplat_test/cxplat_test.vcxproj.filters
+++ b/cxplat/cxplat_test/cxplat_test.vcxproj.filters
@@ -30,7 +30,7 @@
     <ClCompile Include="cxplat_initialization_test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="cxplat_fault_injection.cpp">
+    <ClCompile Include="cxplat_fault_injection_test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/cxplat/cxplat_test/cxplat_test.vcxproj.filters
+++ b/cxplat/cxplat_test/cxplat_test.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="cxplat_initialization_test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="cxplat_fault_injection.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/cxplat/inc/winuser/cxplat_fault_injection.h
+++ b/cxplat/inc/winuser/cxplat_fault_injection.h
@@ -14,11 +14,13 @@ CXPLAT_EXTERN_C_BEGIN
  *
  * @param[in] stack_depth Number of stack frames to capture when a fault is
  * injected.
+ * @param[in] module_under_test Base address of the module under test.
+ * @param[in] module_under_test_size Size of the module under test.
  * @retval CXPLAT_STATUS_SUCCESS The operation was successful.
  * @retval CXPLAT_STATUS_OUT_OF_MEMORY Operation failed due to memory allocation failure.
  */
 cxplat_status_t
-cxplat_fault_injection_initialize(size_t stack_depth) CXPLAT_NOEXCEPT;
+cxplat_fault_injection_initialize(size_t stack_depth, void* module_handle) CXPLAT_NOEXCEPT;
 
 /**
  * @brief Uninitialize fault injection. This must be called after all other
@@ -44,5 +46,11 @@ cxplat_fault_injection_inject_fault() CXPLAT_NOEXCEPT;
  */
 bool
 cxplat_fault_injection_is_enabled() CXPLAT_NOEXCEPT;
+
+/**
+ * @brief Reset fault injection. This function is thread safe.
+ */
+void
+cxplat_fault_injection_reset() CXPLAT_NOEXCEPT;
 
 CXPLAT_EXTERN_C_END

--- a/cxplat/inc/winuser/cxplat_fault_injection.h
+++ b/cxplat/inc/winuser/cxplat_fault_injection.h
@@ -14,13 +14,12 @@ CXPLAT_EXTERN_C_BEGIN
  *
  * @param[in] stack_depth Number of stack frames to capture when a fault is
  * injected.
- * @param[in] module_under_test Base address of the module under test.
- * @param[in] module_under_test_size Size of the module under test.
+ *
  * @retval CXPLAT_STATUS_SUCCESS The operation was successful.
  * @retval CXPLAT_STATUS_OUT_OF_MEMORY Operation failed due to memory allocation failure.
  */
 cxplat_status_t
-cxplat_fault_injection_initialize(size_t stack_depth, void* module_handle) CXPLAT_NOEXCEPT;
+cxplat_fault_injection_initialize(size_t stack_depth) CXPLAT_NOEXCEPT;
 
 /**
  * @brief Uninitialize fault injection. This must be called after all other
@@ -52,5 +51,17 @@ cxplat_fault_injection_is_enabled() CXPLAT_NOEXCEPT;
  */
 void
 cxplat_fault_injection_reset() CXPLAT_NOEXCEPT;
+
+/**
+ * @brief Add a module to the fault injection list. This function is thread safe.
+ *
+ * @param module_handle
+ * @return cxplat_status_t
+ */
+cxplat_status_t
+cxplat_fault_injection_add_module(void* module_handle) CXPLAT_NOEXCEPT;
+
+cxplat_status_t
+cxplat_fault_injection_remove_module(void* module_handle) CXPLAT_NOEXCEPT;
 
 CXPLAT_EXTERN_C_END

--- a/cxplat/inc/winuser/cxplat_fault_injection.h
+++ b/cxplat/inc/winuser/cxplat_fault_injection.h
@@ -59,9 +59,9 @@ cxplat_fault_injection_reset() CXPLAT_NOEXCEPT;
  * @return cxplat_status_t
  */
 cxplat_status_t
-cxplat_fault_injection_add_module(void* module_handle) CXPLAT_NOEXCEPT;
+cxplat_fault_injection_add_module(_In_ void* module_handle) CXPLAT_NOEXCEPT;
 
 cxplat_status_t
-cxplat_fault_injection_remove_module(void* module_handle) CXPLAT_NOEXCEPT;
+cxplat_fault_injection_remove_module(_In_ void* module_handle) CXPLAT_NOEXCEPT;
 
 CXPLAT_EXTERN_C_END

--- a/cxplat/inc/winuser/cxplat_fault_injection.h
+++ b/cxplat/inc/winuser/cxplat_fault_injection.h
@@ -17,6 +17,7 @@ CXPLAT_EXTERN_C_BEGIN
  *
  * @retval CXPLAT_STATUS_SUCCESS The operation was successful.
  * @retval CXPLAT_STATUS_OUT_OF_MEMORY Operation failed due to memory allocation failure.
+ * @retval CXPLAT_STATUS_INVALID_STATE Operation failed due to invalid state (e.g. already initialized).
  */
 cxplat_status_t
 cxplat_fault_injection_initialize(size_t stack_depth) CXPLAT_NOEXCEPT;
@@ -55,12 +56,22 @@ cxplat_fault_injection_reset() CXPLAT_NOEXCEPT;
 /**
  * @brief Add a module to the fault injection list. This function is thread safe.
  *
- * @param module_handle
- * @return cxplat_status_t
+ * @param[in] module_handle
+ * @retval CXPLAT_STATUS_SUCCESS The operation was successful.
+ * @retval CXPLAT_STATUS_OUT_OF_MEMORY Operation failed due to memory allocation failure.
+ * @retval CXPLAT_STATUS_INVALID_STATE Operation failed due to invalid state (e.g. already added).
  */
 cxplat_status_t
 cxplat_fault_injection_add_module(_In_ void* module_handle) CXPLAT_NOEXCEPT;
 
+/**
+ * @brief Remove a module from the fault injection list. This function is thread safe.
+ *
+ * @param[in] module_handle
+ * @retval CXPLAT_STATUS_SUCCESS The operation was successful.
+ * @retval CXPLAT_STATUS_OUT_OF_MEMORY Operation failed due to memory allocation failure.
+ * @retval CXPLAT_STATUS_INVALID_STATE Operation failed due to invalid state (e.g. already removed).
+ */
 cxplat_status_t
 cxplat_fault_injection_remove_module(_In_ void* module_handle) CXPLAT_NOEXCEPT;
 

--- a/cxplat/src/cxplat_winuser/cxplat_winuser.cpp
+++ b/cxplat/src/cxplat_winuser/cxplat_winuser.cpp
@@ -6,9 +6,9 @@
 #include "leak_detector.h"
 #include "symbol_decoder.h"
 
-#include <Psapi.h>
 #include <algorithm>
 #include <memory>
+#include <psapi.h>
 #include <string>
 
 extern "C" bool cxplat_fuzzing_enabled = false;
@@ -90,11 +90,38 @@ _get_environment_variable_as_size_t(const std::string& name)
 static std::mutex cxplat_initialization_mutex;
 static ULONG _cxplat_initialization_count = 0;
 
+inline
+static
+HMODULE _cxplat_get_caller_module()
+{
+    // Capture the caller's module handle and address.
+    uintptr_t caller_address;
+    unsigned long caller_address_hash;
+    HMODULE module_handle;
+    if (CaptureStackBackTrace(1, 1, (void**)&caller_address, &caller_address_hash) == 0) {
+        return NULL;
+    }
+    if (!GetModuleHandleEx(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            reinterpret_cast<LPCTSTR>(caller_address),
+            &module_handle)) {
+        return NULL;
+    }
+    return module_handle;
+}
+
 cxplat_status_t
 cxplat_initialize()
 {
+
     std::unique_lock lock(cxplat_initialization_mutex);
     if (_cxplat_initialization_count > 0) {
+        if (cxplat_fault_injection_is_enabled()) {
+            if (cxplat_fault_injection_add_module(_cxplat_get_caller_module()) != 0) {
+                return CXPLAT_STATUS_NO_MEMORY;
+            }
+        }
+
         // Already initialized.
         _cxplat_initialization_count++;
         return CXPLAT_STATUS_SUCCESS;
@@ -112,20 +139,11 @@ cxplat_initialize()
             }
         }
         if (fault_injection_stack_depth && !cxplat_fault_injection_is_enabled()) {
-            uintptr_t caller_address;
-            unsigned long caller_address_hash;
-            HMODULE module_handle;
-            if (CaptureStackBackTrace(1, 1, (void**)&caller_address, &caller_address_hash) == 0) {
-                return CXPLAT_STATUS_NO_MEMORY;
-            }
-            if (!GetModuleHandleEx(
-                    GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                    reinterpret_cast<LPCTSTR>(caller_address),
-                    &module_handle)) {
+            if (cxplat_fault_injection_initialize(fault_injection_stack_depth) != 0) {
                 return CXPLAT_STATUS_NO_MEMORY;
             }
 
-            if (cxplat_fault_injection_initialize(fault_injection_stack_depth, module_handle) != 0) {
+            if (cxplat_fault_injection_add_module(_cxplat_get_caller_module()) != 0) {
                 return CXPLAT_STATUS_NO_MEMORY;
             }
             // Set flag to remove some asserts that fire from incorrect client behavior.
@@ -154,6 +172,7 @@ cxplat_cleanup()
     CXPLAT_RUNTIME_ASSERT(_cxplat_initialization_count > 0);
     _cxplat_initialization_count--;
     if (_cxplat_initialization_count > 0) {
+        cxplat_fault_injection_remove_module(_cxplat_get_caller_module());
         // Don't clean up until the count hits 0.
         return;
     }

--- a/cxplat/src/cxplat_winuser/cxplat_winuser.cpp
+++ b/cxplat/src/cxplat_winuser/cxplat_winuser.cpp
@@ -90,9 +90,8 @@ _get_environment_variable_as_size_t(const std::string& name)
 static std::mutex cxplat_initialization_mutex;
 static ULONG _cxplat_initialization_count = 0;
 
-inline
-static
-HMODULE _cxplat_get_caller_module()
+inline static HMODULE
+_cxplat_get_caller_module()
 {
     // Capture the caller's module handle and address.
     uintptr_t caller_address;

--- a/cxplat/src/cxplat_winuser/fault_injection.cpp
+++ b/cxplat/src/cxplat_winuser/fault_injection.cpp
@@ -180,8 +180,7 @@ class cxplat_fault_injection_recursion_guard
     }
 };
 
-_cxplat_fault_injection::_cxplat_fault_injection(size_t stack_depth)
-    : _stack_depth(stack_depth)
+_cxplat_fault_injection::_cxplat_fault_injection(size_t stack_depth) : _stack_depth(stack_depth)
 {
     if (_stack_depth == 0) {
         _stack_depth = CXPLAT_FAULT_STACK_CAPTURE_FRAME_COUNT_FOR_HASH;
@@ -372,7 +371,6 @@ _cxplat_fault_injection::find_base_address(uintptr_t address)
     return (address >= iter->first && address < iter->first + iter->second) ? iter->first : 0;
 }
 
-
 cxplat_status_t
 cxplat_fault_injection_initialize(size_t stack_depth) noexcept
 {
@@ -418,7 +416,7 @@ cxplat_fault_injection_reset() noexcept
 }
 
 cxplat_status_t
-cxplat_fault_injection_add_module(void* module_under_test) noexcept
+cxplat_fault_injection_add_module(_In_ void* module_under_test) noexcept
 {
     try {
         if (_cxplat_fault_injection_singleton) {
@@ -429,7 +427,7 @@ cxplat_fault_injection_add_module(void* module_under_test) noexcept
             }
             if (!GetModuleInformation(
                     GetCurrentProcess(),
-                    reinterpret_cast<HMODULE>(module_under_test),
+                    reinterpret_cast<const HMODULE>(module_under_test),
                     &module_info,
                     sizeof(module_info))) {
                 throw std::runtime_error("GetModuleInformation failed");


### PR DESCRIPTION
Resolves: #107

Fault injection was originally designed as a static lib. It would then inject faults in code in the current process.

Now that it is being used as a DLL, it inject faults in the module that calls cxplat_fault_injection_initialize.