### PR TITLE
Don't use ExAllocatePool2 as it doesn't exist downlevel

### DIFF
--- a/cxplat/src/cxplat_winkernel/memory_winkernel.c
+++ b/cxplat/src/cxplat_winkernel/memory_winkernel.c
@@ -5,10 +5,31 @@
 
 #include <wdm.h>
 
+__forceinline POOL_TYPE
+_pool_flags_to_type(cxplat_pool_flags_t pool_flags)
+{
+    POOL_TYPE pool_type = NonPagedPool;
+    if (pool_flags & CXPLAT_POOL_FLAG_PAGED) {
+        pool_type |= PagedPool;
+    }
+    if (pool_flags & CXPLAT_POOL_FLAG_CACHE_ALIGNED) {
+        pool_type |= NonPagedPoolCacheAligned;
+    }
+    if (pool_flags & CXPLAT_POOL_FLAG_NON_PAGED) {
+        pool_type |= NonPagedPoolNx;
+    }
+    return pool_type;
+}
+
 __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(size) void* cxplat_allocate(
     cxplat_pool_flags_t pool_flags, size_t size, uint32_t tag)
 {
-    return ExAllocatePool2(pool_flags, size, tag);
+    // ExAllocatePool2 would be perfect here, but it doesn't exist prior to Windows 10 version 2004
+    // or Windows Server 2022.  So we need to wrap ExAllocatePoolWithTag instead by converting
+    // pool flags to pool type.
+    POOL_TYPE pool_type = _pool_flags_to_type(pool_flags);
+#pragma warning(suppress: 4996) // ExAllocatePoolWithTag is deprecated, use ExAllocatePool2
+    return ExAllocatePoolWithTag(pool_type, size, tag);
 }
 
 __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_writes_maybenull_(new_size) void* cxplat_reallocate(


### PR DESCRIPTION
Per https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2, ExAllocatePool2 is fairly new and isn't available downlevel.