### PR TITLE
Queue DPC on timer expiry

### DIFF
--- a/src/ke.cpp
+++ b/src/ke.cpp
@@ -701,10 +701,7 @@ _usersim_timer_callback(
     timer->signaled = TRUE;
 
     if (timer->dpc) {
-        KIRQL old_irql = KeRaiseIrqlToDpcLevel();
-        timer->dpc->work_item_routine(
-            timer->dpc, timer->dpc->context, timer->dpc->parameter_1, timer->dpc->parameter_2);
-        KeLowerIrql(old_irql);
+        KeInsertQueueDpc(timer->dpc, timer->dpc->parameter_1, timer->dpc->parameter_2);
     }
 }
 


### PR DESCRIPTION
Running the DPC from the timer thread give incorrect behavior. The DPC should run on the CPU specified in the DPC.

Resolves: #132 