### PR TITLE
Switch thread pool and processor info init

### DIFF
--- a/cxplat/src/cxplat_winuser/cxplat_winuser.cpp
+++ b/cxplat/src/cxplat_winuser/cxplat_winuser.cpp
@@ -159,14 +159,13 @@ cxplat_initialize()
         }
 #endif
 
-        cxplat_status_t status = cxplat_winuser_initialize_processor_info();
+        cxplat_status_t status = cxplat_winuser_initialize_thread_pool();
         if (!CXPLAT_SUCCEEDED(status)) {
             return status;
         }
 
-        status = cxplat_winuser_initialize_thread_pool();
+        status = cxplat_winuser_initialize_processor_info();
         if (!CXPLAT_SUCCEEDED(status)) {
-            cxplat_winuser_clean_up_processor_info();
             return status;
         }
     } catch (const std::bad_alloc&) {


### PR DESCRIPTION
Work around for #153 

If the API cxplat_winuser_initialize_thread_pool is not called, then cxplat_cleanup throws an unhandled exception.
