### PR TITLE
Make rundown conditional on pool

### DIFF
--- a/cxplat/src/cxplat_winuser/workitem_winuser.cpp
+++ b/cxplat/src/cxplat_winuser/workitem_winuser.cpp
@@ -139,6 +139,10 @@ Exit:
 void
 cxplat_wait_for_preemptible_work_items_complete()
 {
+    if (!_pool) {
+        return;
+    }
+
     cxplat_wait_for_rundown_protection_release(&_cxplat_preemptible_work_items_rundown_reference);
 }
 


### PR DESCRIPTION
Resolves: #153 

The API cxplat_wait_for_preemptible_work_items_complete throws an unhandled exception if cxplat_winuser_initialize_thread_pool was not successful.