### PR TITLE
Fix signature of KeSetTargetProcessorDpcEx

### DIFF
--- a/inc/usersim/ke.h
+++ b/inc/usersim/ke.h
@@ -283,7 +283,7 @@ void
 KeSetTargetProcessorDpc(_Inout_ PRKDPC dpc, CCHAR number);
 
 USERSIM_API
-void
+NTSTATUS
 KeSetTargetProcessorDpcEx(_Inout_ PRKDPC dpc, PPROCESSOR_NUMBER proc_number);
 
 void

--- a/src/ke.cpp
+++ b/src/ke.cpp
@@ -638,10 +638,11 @@ KeSetTargetProcessorDpc(_Inout_ PRKDPC dpc, CCHAR number)
     dpc->cpu_id = number;
 }
 
-void
+NTSTATUS
 KeSetTargetProcessorDpcEx(_Inout_ PRKDPC dpc, PPROCESSOR_NUMBER proc_number)
 {
     dpc->cpu_id = KeGetProcessorIndexFromNumber(proc_number);
+    return STATUS_SUCCESS;
 }
 
 BOOLEAN


### PR DESCRIPTION
KeSetTargetProcessorDpcEx should return NTSTATUS not void.