### PR TITLE
Add missing forward declaration for RTL_AVL_TABLE

### DIFF
--- a/inc/usersim/rtl.h
+++ b/inc/usersim/rtl.h
@@ -214,6 +214,8 @@ typedef enum _RTL_GENERIC_COMPARE_RESULTS
     GenericEqual
 } RTL_GENERIC_COMPARE_RESULTS;
 
+struct _RTL_AVL_TABLE;
+
 typedef RTL_GENERIC_COMPARE_RESULTS (*PRTL_AVL_COMPARE_ROUTINE)(
     _In_ struct _RTL_AVL_TABLE* Table, _In_ PVOID FirstStruct, _In_ PVOID SecondStruct);
 


### PR DESCRIPTION
PR #178 added support for the RTL_AVL_TABLE but was missing a forward declaration of the struct required for compiling. This change addresses that by adding the necessary declaration.