### PR TITLE
Simulate EX_RUNDOWN_REF_CACHE_AWARE APIS

### DIFF
--- a/inc/usersim/ex.h
+++ b/inc/usersim/ex.h
@@ -36,7 +36,11 @@ typedef struct _EX_SPIN_LOCK
 {
     SRWLOCK lock;
 } EX_SPIN_LOCK;
+
 typedef cxplat_rundown_reference_t EX_RUNDOWN_REF;
+
+// Initial usersim version of this API will not be cache aware and will use the same type as EX_RUNDOWN_REF.
+typedef cxplat_rundown_reference_t EX_RUNDOWN_REF_CACHE_AWARE;
 
 //
 // Pool Allocation routines (in pool.c)
@@ -103,6 +107,26 @@ ExAcquireRundownProtection(_Inout_ EX_RUNDOWN_REF* rundown_ref);
 USERSIM_API
 void
 ExReleaseRundownProtection(_Inout_ EX_RUNDOWN_REF* rundown_ref);
+
+USERSIM_API
+EX_RUNDOWN_REF_CACHE_AWARE*
+ExAllocateCacheAwareRundownProtection(
+    _In_ __drv_strictTypeMatch(__drv_typeExpr) POOL_TYPE PoolType, unsigned long PoolTag);
+
+USERSIM_API
+BOOLEAN ExAcquireRundownProtectionCacheAware(
+  _Inout_ EX_RUNDOWN_REF_CACHE_AWARE* RunRefCacheAware
+);
+
+USERSIM_API
+void ExReleaseRundownProtectionCacheAware(
+  _Inout_ EX_RUNDOWN_REF_CACHE_AWARE* RunRefCacheAware
+);
+
+USERSIM_API
+void ExFreeCacheAwareRundownProtection(
+  _Inout_ EX_RUNDOWN_REF_CACHE_AWARE* RunRefCacheAware
+);
 
 USERSIM_API
 _Acquires_exclusive_lock_(push_lock->lock) void ExAcquirePushLockExclusiveEx(

--- a/src/ex.cpp
+++ b/src/ex.cpp
@@ -45,6 +45,37 @@ ExReleaseRundownProtection(_Inout_ EX_RUNDOWN_REF* rundown_reference)
     cxplat_release_rundown_protection(rundown_reference);
 }
 
+EX_RUNDOWN_REF_CACHE_AWARE*
+ExAllocateCacheAwareRundownProtection(
+    _In_ __drv_strictTypeMatch(__drv_typeExpr) POOL_TYPE PoolType, unsigned long PoolTag)
+{
+    EX_RUNDOWN_REF_CACHE_AWARE* rundown_reference =
+        (EX_RUNDOWN_REF_CACHE_AWARE*)ExAllocatePoolWithTag(PoolType, sizeof(EX_RUNDOWN_REF_CACHE_AWARE), PoolTag);
+
+    if (rundown_reference != nullptr) {
+        cxplat_initialize_rundown_protection(rundown_reference);
+    }
+    return rundown_reference;
+}
+
+BOOLEAN
+ExAcquireRundownProtectionCacheAware(_Inout_ EX_RUNDOWN_REF_CACHE_AWARE* RunRefCacheAware)
+{
+    return (BOOLEAN)cxplat_acquire_rundown_protection(RunRefCacheAware);
+}
+
+void
+ExReleaseRundownProtectionCacheAware(_Inout_ EX_RUNDOWN_REF_CACHE_AWARE* RunRefCacheAware)
+{
+    cxplat_release_rundown_protection(RunRefCacheAware);
+}
+
+void
+ExFreeCacheAwareRundownProtection(_Inout_ EX_RUNDOWN_REF_CACHE_AWARE* RunRefCacheAware)
+{
+    ExFreePool(RunRefCacheAware);
+}
+
 _Acquires_exclusive_lock_(push_lock->lock) void ExAcquirePushLockExclusiveEx(
     _Inout_ _Requires_lock_not_held_(*_Curr_) _Acquires_lock_(*_Curr_) EX_PUSH_LOCK* push_lock,
     _In_ unsigned long flags)


### PR DESCRIPTION
This pull request primarily introduces a new type `EX_RUNDOWN_REF_CACHE_AWARE`, which is an extension of `EX_RUNDOWN_REF` and is designed to be cache aware for better performance. It also adds new APIs to allocate, acquire, release, and free this new type. Additionally, it includes tests for these new APIs and the existing `EX_RUNDOWN_REF` APIs.

Here are the most important changes:

**Type and API additions:**

* [`inc/usersim/ex.h`](diffhunk://#diff-18945575e3a48a3cd91cdbb2c192cfd97519c083f41e146594d5ed9ff8a2ea80R39-R44): Introduced a new type `EX_RUNDOWN_REF_CACHE_AWARE` which is similar to `EX_RUNDOWN_REF` but is cache aware. This type is expected to improve performance by being aware of the cache. Also, added new APIs `ExAllocateCacheAwareRundownProtection`, `ExAcquireRundownProtectionCacheAware`, `ExReleaseRundownProtectionCacheAware`, and `ExFreeCacheAwareRundownProtection` to work with this new type. [[1]](diffhunk://#diff-18945575e3a48a3cd91cdbb2c192cfd97519c083f41e146594d5ed9ff8a2ea80R39-R44) [[2]](diffhunk://#diff-18945575e3a48a3cd91cdbb2c192cfd97519c083f41e146594d5ed9ff8a2ea80R111-R130)
* [`src/ex.cpp`](diffhunk://#diff-168009b9862868e394ab997ce42c70fc64d3bba1bb4f09a667487294f4ce1cb2R48-R78): Implemented the new APIs introduced in `inc/usersim/ex.h`. These APIs are designed to allocate, acquire, release, and free the `EX_RUNDOWN_REF_CACHE_AWARE` type.

**Test additions:**

* [`tests/ex_test.cpp`](diffhunk://#diff-00db1c45ecfdd3d762bf7365afb7b2d249ba04a1bb4eeca33c404e97682b2201R10-R12): Added new tests for the `EX_RUNDOWN_REF` and `EX_RUNDOWN_REF_CACHE_AWARE` APIs. These tests ensure that the APIs behave as expected, especially in terms of acquiring and releasing rundown protections. [[1]](diffhunk://#diff-00db1c45ecfdd3d762bf7365afb7b2d249ba04a1bb4eeca33c404e97682b2201R10-R12) [[2]](diffhunk://#diff-00db1c45ecfdd3d762bf7365afb7b2d249ba04a1bb4eeca33c404e97682b2201R123-R230)