### PR TITLE
KeSetSystemGroupAffinityThread does not match kernel behavior

### DIFF
--- a/src/ke.cpp
+++ b/src/ke.cpp
@@ -227,7 +227,6 @@ KeSetSystemAffinityThreadEx(KAFFINITY affinity)
     _usersim_thread_affinity.Group = old_affinity.Group;
     _usersim_thread_affinity.Mask = affinity;
     if (KeGetCurrentIrql() < DISPATCH_LEVEL && SetThreadAffinityMask(GetCurrentThread(), affinity) == 0) {
-        unsigned long error = GetLastError();
         return 0;
     }
     return (KAFFINITY)old_affinity.Mask;

--- a/src/ke.cpp
+++ b/src/ke.cpp
@@ -227,6 +227,7 @@ KeSetSystemAffinityThreadEx(KAFFINITY affinity)
     _usersim_thread_affinity.Group = old_affinity.Group;
     _usersim_thread_affinity.Mask = affinity;
     if (KeGetCurrentIrql() < DISPATCH_LEVEL && SetThreadAffinityMask(GetCurrentThread(), affinity) == 0) {
+        _usersim_thread_affinity = old_affinity;
         return 0;
     }
     return (KAFFINITY)old_affinity.Mask;

--- a/src/ke.cpp
+++ b/src/ke.cpp
@@ -224,6 +224,12 @@ KeSetSystemAffinityThreadEx(KAFFINITY affinity)
 {
     GROUP_AFFINITY old_affinity;
     usersim_get_current_thread_group_affinity(&old_affinity);
+    // Reject affinities that are not valid for the current group.
+    // Assume that the affinity mask is contiguous.
+    KAFFINITY valid_affinity_mask = (1 << KeQueryMaximumProcessorCountEx(old_affinity.Group)) - 1;
+    if ((affinity & valid_affinity_mask) == 0) {
+        return 0;
+    }
     _usersim_thread_affinity.Group = old_affinity.Group;
     _usersim_thread_affinity.Mask = affinity;
     if (KeGetCurrentIrql() < DISPATCH_LEVEL && SetThreadAffinityMask(GetCurrentThread(), affinity) == 0) {

--- a/src/ke.cpp
+++ b/src/ke.cpp
@@ -228,7 +228,7 @@ KeSetSystemAffinityThreadEx(KAFFINITY affinity)
     _usersim_thread_affinity.Mask = affinity;
     if (KeGetCurrentIrql() < DISPATCH_LEVEL && SetThreadAffinityMask(GetCurrentThread(), affinity) == 0) {
         unsigned long error = GetLastError();
-        KeBugCheckEx(0, error, 0, 0, 0);
+        return 0;
     }
     return (KAFFINITY)old_affinity.Mask;
 }


### PR DESCRIPTION
This pull request includes a change to the `KeSetSystemAffinityThreadEx(KAFFINITY affinity)` function in the `src/ke.cpp` file. The change modifies the error handling mechanism. Instead of triggering a bug check when an error occurs, the function now returns 0.

In detail:

* [`src/ke.cpp`](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bL231-R231): Modified the `KeSetSystemAffinityThreadEx(KAFFINITY affinity)` function to return 0 instead of triggering a bug check when `SetThreadAffinityMask(GetCurrentThread(), affinity)` returns an error.