### PR TITLE
Permit caller opt-in to improve raise/lower irql perf

### DIFF
--- a/inc/usersim/ke.h
+++ b/inc/usersim/ke.h
@@ -85,6 +85,14 @@ usersim_initialize_irql();
 void
 usersim_clean_up_irql();
 
+USERSIM_API
+void
+usersim_set_affinity_and_priority_override(uint32_t processor_index);
+
+USERSIM_API
+void
+usersim_clear_affinity_and_priority_override();
+
 #pragma endregion irqls
 
 #pragma region spin_locks

--- a/tests/ke_test.cpp
+++ b/tests/ke_test.cpp
@@ -38,6 +38,37 @@ TEST_CASE("irql", "[ke]")
     REQUIRE(KeGetCurrentIrql() == PASSIVE_LEVEL);
 }
 
+TEST_CASE("irql_perf_override", "[ke]")
+{
+    usersim_set_affinity_and_priority_override(0);
+
+    REQUIRE(KeGetCurrentIrql() == PASSIVE_LEVEL);
+
+    KIRQL old_irql;
+    KeRaiseIrql(DISPATCH_LEVEL, &old_irql);
+    REQUIRE(old_irql == PASSIVE_LEVEL);
+    REQUIRE(KeGetCurrentIrql() == DISPATCH_LEVEL);
+
+    KeRaiseIrql(DISPATCH_LEVEL, &old_irql);
+    REQUIRE(old_irql == DISPATCH_LEVEL);
+    REQUIRE(KeGetCurrentIrql() == DISPATCH_LEVEL);
+
+    KeLowerIrql(DISPATCH_LEVEL);
+    REQUIRE(KeGetCurrentIrql() == DISPATCH_LEVEL);
+
+    KeLowerIrql(PASSIVE_LEVEL);
+    REQUIRE(KeGetCurrentIrql() == PASSIVE_LEVEL);
+
+    old_irql = KeRaiseIrqlToDpcLevel();
+    REQUIRE(old_irql == PASSIVE_LEVEL);
+    REQUIRE(KeGetCurrentIrql() == DISPATCH_LEVEL);
+
+    KeLowerIrql(old_irql);
+    REQUIRE(KeGetCurrentIrql() == PASSIVE_LEVEL);
+
+    usersim_clear_affinity_and_priority_override();
+}
+
 TEST_CASE("KfRaiseIrql", "[ke]")
 {
     REQUIRE(KeGetCurrentIrql() == PASSIVE_LEVEL);


### PR DESCRIPTION
The cost of emulating KeRaiseIrql and KeLowerIrql significantly distort performance tests when running against usersim.

For the use case where performance tests are being run, it is useful to override the behavior of KeRaiseIrql and KeLowerIrql by pinning the CPU to a processor and raising the thread priority.