### PR TITLE
User/austinl/ps get process exit status

### DIFF
--- a/inc/usersim/ps.h
+++ b/inc/usersim/ps.h
@@ -14,6 +14,16 @@ USERSIM_API
 HANDLE
 PsGetCurrentProcessId();
 
+typedef NTSTATUS (*PGETPROCESSEXITSTATUS)(_In_ PEPROCESS process);
+
+USERSIM_API
+NTSTATUS
+PsGetProcessExitStatus(_In_ PEPROCESS Process);
+
+USERSIM_API
+void
+usersime_set_process_exit_status_callback(_In_ PGETPROCESSEXITSTATUS callback);
+
 USERSIM_API
 _IRQL_requires_max_(DISPATCH_LEVEL) NTKERNELAPI HANDLE PsGetCurrentThreadId();
 

--- a/src/ps.cpp
+++ b/src/ps.cpp
@@ -4,7 +4,6 @@
 #include "kernel_um.h"
 #include "platform.h"
 #include "usersim/ps.h"
-#include <map>
 
 // Ps* functions.
 

--- a/src/ps.cpp
+++ b/src/ps.cpp
@@ -4,6 +4,7 @@
 #include "kernel_um.h"
 #include "platform.h"
 #include "usersim/ps.h"
+#include <map>
 
 // Ps* functions.
 
@@ -13,6 +14,25 @@ PsGetCurrentProcessId() { return (HANDLE)(uintptr_t)GetCurrentProcessId(); }
 _IRQL_requires_max_(DISPATCH_LEVEL) NTKERNELAPI HANDLE PsGetCurrentThreadId()
 {
     return (HANDLE)(uintptr_t)GetCurrentThreadId();
+}
+
+static PGETPROCESSEXITSTATUS _usersim_get_process_exit_status_callback = NULL;
+
+NTSTATUS
+PsGetProcessExitStatus(_In_ PEPROCESS Process) {
+    if (_usersim_get_process_exit_status_callback != NULL) {
+        return _usersim_get_process_exit_status_callback(Process);
+    }
+
+    // Fall back to a failure code
+    return -1;
+}
+
+USERSIM_API
+void
+usersime_set_process_exit_status_callback(_In_ PGETPROCESSEXITSTATUS callback)
+{
+    _usersim_get_process_exit_status_callback = callback;
 }
 
 static PCREATE_PROCESS_NOTIFY_ROUTINE_EX _usersim_process_creation_notify_routine = NULL;

--- a/tests/ps_test.cpp
+++ b/tests/ps_test.cpp
@@ -42,3 +42,23 @@ TEST_CASE("PsSetCreateProcessNotifyRoutineEx", "[ps]")
     status = PsSetCreateProcessNotifyRoutineEx(notify_routine, TRUE);
     REQUIRE(status == STATUS_SUCCESS);
 }
+
+TEST_CASE("PsGetProcessExitStatus", "[ps]")
+{
+    // If no callback is installed, we default to -1
+    auto status = PsGetProcessExitStatus((PEPROCESS)0);
+    REQUIRE(status == -1);
+
+    usersime_set_process_exit_status_callback([](PEPROCESS proc) -> NTSTATUS { return ((int)proc)  +  1; });
+
+    status = PsGetProcessExitStatus((PEPROCESS)0);
+    REQUIRE(status == 1);
+
+    status = PsGetProcessExitStatus((PEPROCESS)1234);
+    REQUIRE(status == 1235);
+
+    // Setting back to a NULL callback reverts to returning -1
+    usersime_set_process_exit_status_callback(NULL);
+    status = PsGetProcessExitStatus((PEPROCESS)0);
+    REQUIRE(status == -1);
+}

--- a/tests/tests.vcxproj
+++ b/tests/tests.vcxproj
@@ -156,6 +156,7 @@
     <ClCompile Include="mm_test.cpp" />
     <ClCompile Include="nmr_test.cpp" />
     <ClCompile Include="ob_test.cpp" />
+    <ClCompile Include="ps_test.cpp" />
     <ClCompile Include="rtl_test.cpp" />
     <ClCompile Include="se_test.cpp" />
     <ClCompile Include="wdf_test.cpp" />

--- a/tests/tests.vcxproj.filters
+++ b/tests/tests.vcxproj.filters
@@ -48,5 +48,8 @@
     <ClCompile Include="io_test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ps_test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds support for the `PsGetProcessExitStatus` API, to be used downstream.  This allows test code to install a callback and simulate any process exit code it wants, so we can test success and failure cases without needing to actually launch processes.

While doing this I noticed that the `Ps*` tests were missing from the `vcxproj` so I added them so they run when running `usersim_tests.exe -d yes` as recommended in the repo readme.  The new test and the existing one both pass locally.