### PR TITLE
Fix SAL on PsGetProcessExitStatus

### DIFF
--- a/inc/usersim/ps.h
+++ b/inc/usersim/ps.h
@@ -17,8 +17,7 @@ PsGetCurrentProcessId();
 typedef NTSTATUS (*PGETPROCESSEXITSTATUS)(_In_ PEPROCESS process);
 
 USERSIM_API
-NTSTATUS
-PsGetProcessExitStatus(_In_ PEPROCESS Process);
+_IRQL_requires_max_(APC_LEVEL) NTKERNELAPI NTSTATUS PsGetProcessExitStatus(_In_ PEPROCESS Process);
 
 USERSIM_API
 void


### PR DESCRIPTION
I misunderstood how the SAL needed to match the DDK on the API I just introduced with #191 

This fixes the SAL to match the DDK.