### PR TITLE
Add TraceLoggingBinary in TraceLoggingProvider

### DIFF
--- a/inc/TraceLoggingProvider.h
+++ b/inc/TraceLoggingProvider.h
@@ -32,6 +32,7 @@ typedef enum
     _tlgBool,
     _tlgGuid,
     _tlgIPv6Address,
+    _tlgBinary,
 } usersim_tlg_type_t;
 
 USERSIM_API
@@ -117,6 +118,9 @@ usersim_trace_logging_set_enabled(bool enabled, UCHAR event_level, ULONGLONG eve
 
 #undef TraceLoggingBool
 #define TraceLoggingBool(...) _tlgBool, USERSIM_VA_ARGC(__VA_ARGS__), __VA_ARGS__
+
+#undef TraceLoggingBinary
+#define TraceLoggingBinary(pValue, cValue, ...) _tlgBinary, pValue, cValue, USERSIM_VA_ARGC(__VA_ARGS__), __VA_ARGS__
 
 #undef TraceLoggingProviderEnabled
 #define TraceLoggingProviderEnabled(hProvider, eventLevel, eventKeyword) \


### PR DESCRIPTION
This PR contains

-  _tlgBinary type for TraceLoggingBinary tracing support to log binary data.

Test log in ebpf-for-windows, where the key in the map is logged as is:
```
[0]0004.1B4C::2024/08/17-14:00:48.586549200 [EbpfForWindowsProvider]{"Message":"
Map lookup","Type":"hash","name":"
xxxx","(key).Length":12,"(key)":"0x0A0101031389000011000000","meta":{"provider":"EbpfForWindowsProvider","event":"EbpfGenericMessage","time":"2024-08-17T21:00:48.5865492Z","cpu":0,"pid":4,"tid":6988,"channel":11,"level":4,"keywords":"0x40"}}
```
Note: map name is masked with xxxx.
Please see the draft PR https://github.com/microsoft/ebpf-for-windows/pull/3781