### PR TITLE
Add mock for `KeExpandKernelStackAndCalloutEx`

### DIFF
--- a/inc/usersim/ke.h
+++ b/inc/usersim/ke.h
@@ -359,6 +359,26 @@ KeBugCheckEx(
     ULONG_PTR bug_check_parameter3,
     ULONG_PTR bug_check_parameter4);
 
+typedef
+_IRQL_requires_same_
+_Function_class_(EXPAND_STACK_CALLOUT)
+VOID
+(NTAPI EXPAND_STACK_CALLOUT) (
+    _In_opt_ PVOID Parameter
+    );
+
+typedef EXPAND_STACK_CALLOUT *PEXPAND_STACK_CALLOUT;
+
+USERSIM_API
+NTSTATUS
+KeExpandKernelStackAndCalloutEx (
+    _In_ PEXPAND_STACK_CALLOUT Callout,
+    _In_opt_ PVOID Parameter,
+    _In_ SIZE_T Size,
+    _In_ BOOLEAN Wait,
+    _In_opt_ PVOID Context
+    );
+
 CXPLAT_EXTERN_C_END
 
 #if defined(__cplusplus)

--- a/src/ke.cpp
+++ b/src/ke.cpp
@@ -975,4 +975,23 @@ _wait_for_kevent(_Inout_ KEVENT* event, _In_opt_ PLARGE_INTEGER timeout)
     }
 }
 
+NTSTATUS KeExpandKernelStackAndCalloutEx(
+    _In_ PEXPAND_STACK_CALLOUT Callout,
+    _In_opt_ PVOID Parameter,
+    _In_ SIZE_T Size,
+    _In_ BOOLEAN Wait,
+    _In_opt_ PVOID Context)
+    {
+        // This is a mock implementation of KeExpandKernelStackAndCalloutEx that does not
+        // actually expand the stack. This is sufficient for the purposes of the tests.
+        UNREFERENCED_PARAMETER(Size);
+        UNREFERENCED_PARAMETER(Wait);
+        UNREFERENCED_PARAMETER(Context);
+
+        // Invoke the callout function.
+        Callout(Parameter);
+
+        return STATUS_SUCCESS;
+    }
+
 #pragma endregion events


### PR DESCRIPTION
This PR adds a mock implementation of `KeExpandKernelStackAndCalloutEx()` API.
