### PR TITLE
Set cmake arch based on matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
       # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
       BUILD_CONFIGURATION: ${{matrix.configurations}}
 
-      BUILD_PLATFORM: x64
+      BUILD_PLATFORM: ${{matrix.architecture}}
       CMAKE_GENERATOR: Visual Studio 17 2022
       PLATFORM_TOOLSET: v143
       CXPLAT_MEMORY_LEAK_DETECTION: true


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration to support multiple architectures.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L100-R100): Modified the `BUILD_PLATFORM` to use `${{matrix.architecture}}` instead of hardcoding `x64`.