### PR TITLE
Add KfLowerIrql shim

### DIFF
--- a/inc/usersim/ke.h
+++ b/inc/usersim/ke.h
@@ -77,6 +77,10 @@ void
 KeLowerIrql(_In_ KIRQL new_irql);
 
 USERSIM_API
+void
+KfLowerIrql(_In_ KIRQL new_irql);
+
+USERSIM_API
 _IRQL_requires_min_(DISPATCH_LEVEL) NTKERNELAPI LOGICAL KeShouldYieldProcessor(VOID);
 
 usersim_result_t

--- a/src/ke.cpp
+++ b/src/ke.cpp
@@ -196,6 +196,11 @@ KeLowerIrql(_In_ KIRQL new_irql)
     ASSERT(result);
 }
 
+void KfLowerIrql(_In_ KIRQL new_irql)
+{
+    return KeLowerIrql(new_irql);
+}
+
 _IRQL_requires_min_(DISPATCH_LEVEL) NTKERNELAPI LOGICAL KeShouldYieldProcessor(VOID) { return false; }
 
 #pragma endregion irqls


### PR DESCRIPTION
This pull request introduces a new function `KfLowerIrql` to the `USERSIM_API` and implements it to call the existing `KeLowerIrql` function. This change enhances the API by providing an additional method to lower the IRQL.

### Enhancements to USERSIM_API:

* [`inc/usersim/ke.h`](diffhunk://#diff-b8dcb37bfb713c012fcd5f680d7c8d09631115092cca187a2bb90707b9c8154eR79-R82): Added the declaration of the `KfLowerIrql` function.
* [`src/ke.cpp`](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bR199-R203): Implemented the `KfLowerIrql` function to call `KeLowerIrql`.