### PR TITLE
Add group affinity stubs

### DIFF
--- a/inc/usersim/ke.h
+++ b/inc/usersim/ke.h
@@ -152,6 +152,17 @@ USERSIM_API
 _IRQL_requires_min_(PASSIVE_LEVEL) _IRQL_requires_max_(APC_LEVEL) NTKERNELAPI VOID
     KeRevertToUserAffinityThreadEx(_In_ KAFFINITY affinity);
 
+USERSIM_API
+void KeSetSystemGroupAffinityThread(
+  _In_            PGROUP_AFFINITY Affinity,
+  _Out_opt_       PGROUP_AFFINITY PreviousAffinity
+);
+
+USERSIM_API
+void KeRevertToUserGroupAffinityThread(
+  PGROUP_AFFINITY PreviousAffinity
+);
+
 typedef struct _kthread* PKTHREAD;
 
 USERSIM_API

--- a/src/ke.cpp
+++ b/src/ke.cpp
@@ -305,6 +305,24 @@ _IRQL_requires_min_(PASSIVE_LEVEL) _IRQL_requires_max_(APC_LEVEL) NTKERNELAPI VO
     KeSetSystemAffinityThreadEx(affinity);
 }
 
+void KeSetSystemGroupAffinityThread(
+  _In_            const PGROUP_AFFINITY Affinity,
+  _Out_opt_       PGROUP_AFFINITY PreviousAffinity
+)
+{
+    if (!SetThreadGroupAffinity(GetCurrentThread(), Affinity, PreviousAffinity)) {
+        DWORD error = GetLastError();
+        assert(error == 0);
+    }
+}
+
+void KeRevertToUserGroupAffinityThread(
+  PGROUP_AFFINITY PreviousAffinity
+)
+{
+    SetThreadGroupAffinity(GetCurrentThread(), PreviousAffinity, NULL);
+}
+
 PKTHREAD
 NTAPI
 KeGetCurrentThread(VOID) { return (PKTHREAD)usersim_get_current_thread_id(); }

--- a/tests/ke_test.cpp
+++ b/tests/ke_test.cpp
@@ -184,6 +184,23 @@ TEST_CASE("threads", "[ke]")
     REQUIRE(old_affinity != 0);
 
     KeRevertToUserAffinityThreadEx(old_affinity);
+
+     for (ULONG i = 0; i < processor_count; i++) {
+        PROCESSOR_NUMBER processor_number = {};
+        GROUP_AFFINITY old_group_affinity = {};
+        GROUP_AFFINITY new_group_affinity = {};
+
+        REQUIRE(KeGetProcessorNumberFromIndex(i, &processor_number) == STATUS_SUCCESS);
+
+        new_group_affinity.Group = processor_number.Group;
+        new_group_affinity.Mask = (ULONG_PTR)1 << processor_number.Number;
+        KeSetSystemGroupAffinityThread(&new_group_affinity, &old_group_affinity);
+        KAFFINITY new_affinity = ((ULONG_PTR)1 << processor_number.Number);
+
+        REQUIRE(KeGetCurrentProcessorNumberEx(NULL) == i);
+
+        KeRevertToUserGroupAffinityThread(&old_group_affinity);
+    }
 }
 
 static void


### PR DESCRIPTION
This pull request introduces new functions to manage group affinity for threads, updates the kernel code to implement these functions, and adds corresponding tests to ensure their correctness. The most important changes include the addition of new API functions, their implementation, and the creation of test cases.

### New API Functions:
* [`inc/usersim/ke.h`](diffhunk://#diff-b8dcb37bfb713c012fcd5f680d7c8d09631115092cca187a2bb90707b9c8154eR155-R165): Added `KeSetSystemGroupAffinityThread` and `KeRevertToUserGroupAffinityThread` to manage group affinity for threads.

### Implementation:
* [`src/ke.cpp`](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bR308-R325): Implemented `KeSetSystemGroupAffinityThread` and `KeRevertToUserGroupAffinityThread` to set and revert group affinity for the current thread.

### Testing:
* [`tests/ke_test.cpp`](diffhunk://#diff-afb8ded167839a6afd7a23e57a4b8611013e46c6de2f8522992e316bd13ba081R187-R203): Added test cases to verify the functionality of `KeSetSystemGroupAffinityThread` and `KeRevertToUserGroupAffinityThread`.