### PR TITLE
Fix build breaks when linking with usersim againt code built against cxplat_kernel

### DIFF
--- a/inc/usersim/ke.h
+++ b/inc/usersim/ke.h
@@ -141,8 +141,13 @@ USERSIM_API
 ULONG
 KeQueryMaximumProcessorCountEx(_In_ USHORT group_number);
 
-#define KeQueryActiveProcessorCount KeQueryMaximumProcessorCount
-#define KeQueryActiveProcessorCountEx KeQueryMaximumProcessorCountEx
+USERSIM_API
+ULONG
+KeQueryActiveProcessorCount();
+
+USERSIM_API
+ULONG
+KeQueryActiveProcessorCountEx(_In_ USHORT group_number);
 
 USERSIM_API
 KAFFINITY

--- a/src/ke.cpp
+++ b/src/ke.cpp
@@ -279,6 +279,18 @@ KeQueryMaximumProcessorCount() { return GetMaximumProcessorCount(ALL_PROCESSOR_G
 ULONG
 KeQueryMaximumProcessorCountEx(_In_ USHORT group_number) { return GetMaximumProcessorCount(group_number); }
 
+ULONG
+KeQueryActiveProcessorCount()
+{
+    return KeQueryMaximumProcessorCount();
+}
+
+ULONG
+KeQueryActiveProcessorCountEx(_In_ USHORT group_number)
+{
+    return KeQueryMaximumProcessorCountEx(group_number);
+}
+
 KAFFINITY
 KeSetSystemAffinityThreadEx(KAFFINITY affinity)
 {
@@ -312,7 +324,11 @@ void KeSetSystemGroupAffinityThread(
 {
     if (!SetThreadGroupAffinity(GetCurrentThread(), Affinity, PreviousAffinity)) {
         DWORD error = GetLastError();
+        #if defined(NDEBUG)
+        UNREFERENCED_PARAMETER(error);
+        #else
         assert(error == 0);
+        #endif
     }
 }
 


### PR DESCRIPTION
This pull request includes changes to the `USERSIM_API` to add new functions and improve error handling in `ke.cpp`. The most important changes include adding new API functions for querying processor counts and refining error handling in the `KeSetSystemGroupAffinityThread` function.

### Additions to `USERSIM_API`:

* Added `KeQueryActiveProcessorCount` and `KeQueryActiveProcessorCountEx` functions to `inc/usersim/ke.h` to provide API access for querying active processor counts.

### Implementation of new functions:

* Implemented `KeQueryActiveProcessorCount` and `KeQueryActiveProcessorCountEx` functions in `src/ke.cpp` to call the corresponding maximum processor count functions.

### Error handling improvements:

* Improved error handling in the `KeSetSystemGroupAffinityThread` function by conditionally using `UNREFERENCED_PARAMETER` for the `error` variable in non-debug builds, and asserting `error` in debug builds.