### PR TITLE
Add cxplat queued spinlocks

### DIFF
--- a/cxplat/cxplat_test/cxplat_processor_test.cpp
+++ b/cxplat/cxplat_test/cxplat_processor_test.cpp
@@ -21,3 +21,13 @@ TEST_CASE("processor", "[processor]")
     REQUIRE(current < maximum);
     cxplat_cleanup();
 }
+
+TEST_CASE("lock", "[processor]")
+{
+    REQUIRE(cxplat_initialize() == CXPLAT_STATUS_SUCCESS);
+    cxplat_spin_lock_t lock;
+    cxplat_lock_queue_handle_t handle;
+    cxplat_acquire_in_stack_queued_spin_lock(&lock, &handle);
+    cxplat_release_in_stack_queued_spin_lock(&handle);
+    cxplat_cleanup();
+}

--- a/cxplat/inc/cxplat_processor.h
+++ b/cxplat/inc/cxplat_processor.h
@@ -27,4 +27,33 @@ cxplat_get_active_processor_count();
 _Must_inspect_result_ uint32_t
 cxplat_get_maximum_processor_count();
 
+typedef struct cxplat_spin_lock
+{
+    uint64_t Reserved[2];
+} cxplat_spin_lock_t;
+
+typedef struct cxplat_lock_queue_handle
+{
+    uint64_t Reserved_1[2];
+    uint8_t Reserved_2;
+} cxplat_lock_queue_handle_t;
+
+_Requires_lock_not_held_(*lock_handle) _Acquires_lock_(*lock_handle) _Post_same_lock_(*spin_lock, *lock_handle)
+    _IRQL_requires_max_(DISPATCH_LEVEL) _IRQL_saves_global_(QueuedSpinLock, lock_handle)
+        _IRQL_raises_(DISPATCH_LEVEL) void cxplat_acquire_in_stack_queued_spin_lock(
+            _Inout_ cxplat_spin_lock_t* spin_lock, _Out_ cxplat_lock_queue_handle_t* lock_handle);
+
+_Requires_lock_held_(*lock_handle) _Releases_lock_(*lock_handle) _IRQL_requires_(DISPATCH_LEVEL)
+    _IRQL_restores_global_(QueuedSpinLock, lock_handle) void cxplat_release_in_stack_queued_spin_lock(
+        _In_ cxplat_lock_queue_handle_t* lock_handle);
+
+_Requires_lock_not_held_(*lock_handle) _Acquires_lock_(*lock_handle) _Post_same_lock_(*spin_lock, *lock_handle)
+    _IRQL_requires_max_(DISPATCH_LEVEL) _IRQL_saves_global_(QueuedSpinLock, lock_handle)
+        _IRQL_raises_(DISPATCH_LEVEL) void cxplat_acquire_in_stack_queued_spin_lock_at_dpc(
+            _Inout_ cxplat_spin_lock_t* spin_lock, _Out_ cxplat_lock_queue_handle_t* lock_handle);
+
+_Requires_lock_held_(*lock_handle) _Releases_lock_(*lock_handle) _IRQL_requires_(DISPATCH_LEVEL)
+    _IRQL_restores_global_(QueuedSpinLock, lock_handle) void cxplat_release_in_stack_queued_spin_lock_from_dpc(
+        _In_ cxplat_lock_queue_handle_t* lock_handle);
+
 CXPLAT_EXTERN_C_END

--- a/cxplat/src/cxplat_winkernel/processor_winkernel.c
+++ b/cxplat/src/cxplat_winkernel/processor_winkernel.c
@@ -21,3 +21,36 @@ cxplat_get_active_processor_count()
 {
     return KeQueryActiveProcessorCountEx(ALL_PROCESSOR_GROUPS);
 }
+
+static_assert(sizeof(cxplat_spin_lock_t) == sizeof(KSPIN_LOCK_QUEUE), "Size mismatch");
+static_assert(sizeof(cxplat_lock_queue_handle_t) == sizeof(KLOCK_QUEUE_HANDLE), "Size mismatch");
+
+_Requires_lock_not_held_(*lock_handle) _Acquires_lock_(*lock_handle) _Post_same_lock_(*spin_lock, *lock_handle)
+    _IRQL_requires_max_(DISPATCH_LEVEL) _IRQL_saves_global_(QueuedSpinLock, lock_handle)
+        _IRQL_raises_(DISPATCH_LEVEL) void cxplat_acquire_in_stack_queued_spin_lock(
+            _Inout_ cxplat_spin_lock_t* spin_lock, _Out_ cxplat_lock_queue_handle_t* lock_handle)
+{
+    KeAcquireInStackQueuedSpinLock((PKSPIN_LOCK)spin_lock, (PKLOCK_QUEUE_HANDLE)lock_handle);
+}
+
+_Requires_lock_held_(*lock_handle) _Releases_lock_(*lock_handle) _IRQL_requires_(DISPATCH_LEVEL)
+    _IRQL_restores_global_(QueuedSpinLock, lock_handle) void cxplat_release_in_stack_queued_spin_lock(
+        _In_ cxplat_lock_queue_handle_t* lock_handle)
+{
+    KeReleaseInStackQueuedSpinLock((PKLOCK_QUEUE_HANDLE)lock_handle);
+}
+
+_Requires_lock_not_held_(*lock_handle) _Acquires_lock_(*lock_handle) _Post_same_lock_(*spin_lock, *lock_handle)
+    _IRQL_requires_max_(DISPATCH_LEVEL) _IRQL_saves_global_(QueuedSpinLock, lock_handle)
+        _IRQL_raises_(DISPATCH_LEVEL) void cxplat_acquire_in_stack_queued_spin_lock_at_dpc(
+            _Inout_ cxplat_spin_lock_t* spin_lock, _Out_ cxplat_lock_queue_handle_t* lock_handle)
+{
+    KeAcquireInStackQueuedSpinLockAtDpcLevel((PKSPIN_LOCK)spin_lock, (PKLOCK_QUEUE_HANDLE)lock_handle);
+}
+
+_Requires_lock_held_(*lock_handle) _Releases_lock_(*lock_handle) _IRQL_requires_(DISPATCH_LEVEL)
+    _IRQL_restores_global_(QueuedSpinLock, lock_handle) void cxplat_release_in_stack_queued_spin_lock_from_dpc(
+        _In_ cxplat_lock_queue_handle_t* lock_handle)
+{
+    KeReleaseInStackQueuedSpinLockFromDpcLevel((PKLOCK_QUEUE_HANDLE)lock_handle);
+}

--- a/cxplat/src/cxplat_winuser/processor_winuser.cpp
+++ b/cxplat/src/cxplat_winuser/processor_winuser.cpp
@@ -95,3 +95,41 @@ cxplat_get_active_processor_count()
 {
     return GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
 }
+
+_Requires_lock_not_held_(*lock_handle) _Acquires_lock_(*lock_handle) _Post_same_lock_(*spin_lock, *lock_handle)
+    _IRQL_requires_max_(DISPATCH_LEVEL) _IRQL_saves_global_(QueuedSpinLock, lock_handle)
+        _IRQL_raises_(DISPATCH_LEVEL) void cxplat_acquire_in_stack_queued_spin_lock(
+            _Inout_ cxplat_spin_lock_t* spin_lock, _Out_ cxplat_lock_queue_handle_t* lock_handle)
+{
+    auto lock = reinterpret_cast<SRWLOCK*>(spin_lock);
+    AcquireSRWLockExclusive(lock);
+
+    lock_handle->Reserved_1[0] = reinterpret_cast<uint64_t>(lock);
+}
+
+_Requires_lock_held_(*lock_handle) _Releases_lock_(*lock_handle) _IRQL_requires_(DISPATCH_LEVEL)
+    _IRQL_restores_global_(QueuedSpinLock, lock_handle) void cxplat_release_in_stack_queued_spin_lock(
+        _In_ cxplat_lock_queue_handle_t* lock_handle)
+{
+    auto lock = reinterpret_cast<SRWLOCK*>(lock_handle->Reserved_1[0]);
+    ReleaseSRWLockExclusive(lock);
+}
+
+_Requires_lock_not_held_(*lock_handle) _Acquires_lock_(*lock_handle) _Post_same_lock_(*spin_lock, *lock_handle)
+    _IRQL_requires_max_(DISPATCH_LEVEL) _IRQL_saves_global_(QueuedSpinLock, lock_handle)
+        _IRQL_raises_(DISPATCH_LEVEL) void cxplat_acquire_in_stack_queued_spin_lock_at_dpc(
+            _Inout_ cxplat_spin_lock_t* spin_lock, _Out_ cxplat_lock_queue_handle_t* lock_handle)
+{
+    auto lock = reinterpret_cast<SRWLOCK*>(spin_lock);
+    AcquireSRWLockExclusive(lock);
+
+    lock_handle->Reserved_1[0] = reinterpret_cast<uint64_t>(lock);
+}
+
+_Requires_lock_held_(*lock_handle) _Releases_lock_(*lock_handle) _IRQL_requires_(DISPATCH_LEVEL)
+    _IRQL_restores_global_(QueuedSpinLock, lock_handle) void cxplat_release_in_stack_queued_spin_lock_from_dpc(
+        _In_ cxplat_lock_queue_handle_t* lock_handle)
+{
+    auto lock = reinterpret_cast<SRWLOCK*>(lock_handle->Reserved_1[0]);
+    ReleaseSRWLockExclusive(lock);
+}


### PR DESCRIPTION
This pull request introduces a new locking mechanism using spin locks and lock queue handles in the `cxplat` library. The changes include new function definitions, type declarations, and test cases to ensure the functionality is correctly implemented and tested.

### New locking mechanism:

* Added new type definitions for `cxplat_spin_lock_t` and `cxplat_lock_queue_handle_t` in `cxplat/inc/cxplat_processor.h` to support the new locking mechanism.
* Implemented new functions for acquiring and releasing in-stack queued spin locks in `cxplat/src/cxplat_winkernel/processor_winkernel.c`. These functions wrap the corresponding kernel functions.
* Added similar functions for acquiring and releasing in-stack queued spin locks in `cxplat/src/cxplat_winuser/processor_winuser.cpp`, using SRW locks for user-mode implementation.

### Testing:

* Added a new test case for the locking mechanism in `cxplat/cxplat_test/cxplat_processor_test.cpp` to validate the initialization, acquisition, and release of the spin lock.