### PR TITLE
Add support for vanilla spinlocks

### DIFF
--- a/cxplat/cxplat_test/cxplat_processor_test.cpp
+++ b/cxplat/cxplat_test/cxplat_processor_test.cpp
@@ -32,6 +32,14 @@ TEST_CASE("queued_spin_lock", "[processor]")
     cxplat_cleanup();
 }
 
+#if !defined(PASSIVE_LEVEL)
+#define PASSIVE_LEVEL 0
+#endif
+
+#if !defined(DISPATCH_LEVEL)
+#define DISPATCH_LEVEL 2
+#endif
+
 TEST_CASE("spin_lock", "[processor]")
 {
     REQUIRE(cxplat_initialize() == CXPLAT_STATUS_SUCCESS);

--- a/cxplat/cxplat_test/cxplat_processor_test.cpp
+++ b/cxplat/cxplat_test/cxplat_processor_test.cpp
@@ -22,12 +22,36 @@ TEST_CASE("processor", "[processor]")
     cxplat_cleanup();
 }
 
-TEST_CASE("lock", "[processor]")
+TEST_CASE("queued_spin_lock", "[processor]")
 {
     REQUIRE(cxplat_initialize() == CXPLAT_STATUS_SUCCESS);
-    cxplat_spin_lock_t lock;
+    cxplat_queue_spin_lock_t lock;
     cxplat_lock_queue_handle_t handle;
     cxplat_acquire_in_stack_queued_spin_lock(&lock, &handle);
     cxplat_release_in_stack_queued_spin_lock(&handle);
+    cxplat_cleanup();
+}
+
+TEST_CASE("spin_lock", "[processor]")
+{
+    REQUIRE(cxplat_initialize() == CXPLAT_STATUS_SUCCESS);
+    cxplat_irql_t irql;
+    cxplat_spin_lock_t lock;
+    REQUIRE(cxplat_get_current_irql() == PASSIVE_LEVEL);
+    irql = cxplat_acquire_spin_lock(&lock);
+    REQUIRE(cxplat_get_current_irql() == DISPATCH_LEVEL);
+    cxplat_release_spin_lock(&lock, irql);
+    REQUIRE(cxplat_get_current_irql() == PASSIVE_LEVEL);
+
+    irql = cxplat_raise_irql(DISPATCH_LEVEL);
+    REQUIRE(cxplat_get_current_irql() == DISPATCH_LEVEL);
+    REQUIRE(irql == PASSIVE_LEVEL);
+    cxplat_acquire_spin_lock_at_dpc_level(&lock);
+
+    cxplat_release_spin_lock_from_dpc_level(&lock);
+
+    cxplat_lower_irql(irql);
+    REQUIRE(cxplat_get_current_irql() == PASSIVE_LEVEL);
+
     cxplat_cleanup();
 }

--- a/cxplat/src/cxplat_winkernel/processor_winkernel.c
+++ b/cxplat/src/cxplat_winkernel/processor_winkernel.c
@@ -22,13 +22,14 @@ cxplat_get_active_processor_count()
     return KeQueryActiveProcessorCountEx(ALL_PROCESSOR_GROUPS);
 }
 
-static_assert(sizeof(cxplat_spin_lock_t) == sizeof(KSPIN_LOCK_QUEUE), "Size mismatch");
+static_assert(sizeof(cxplat_queue_spin_lock_t) == sizeof(KSPIN_LOCK_QUEUE), "Size mismatch");
 static_assert(sizeof(cxplat_lock_queue_handle_t) == sizeof(KLOCK_QUEUE_HANDLE), "Size mismatch");
+static_assert(sizeof(cxplat_spin_lock_t) == sizeof(KSPIN_LOCK), "Size mismatch");
 
 _Requires_lock_not_held_(*lock_handle) _Acquires_lock_(*lock_handle) _Post_same_lock_(*spin_lock, *lock_handle)
     _IRQL_requires_max_(DISPATCH_LEVEL) _IRQL_saves_global_(QueuedSpinLock, lock_handle)
         _IRQL_raises_(DISPATCH_LEVEL) void cxplat_acquire_in_stack_queued_spin_lock(
-            _Inout_ cxplat_spin_lock_t* spin_lock, _Out_ cxplat_lock_queue_handle_t* lock_handle)
+            _Inout_ cxplat_queue_spin_lock_t* spin_lock, _Out_ cxplat_lock_queue_handle_t* lock_handle)
 {
     KeAcquireInStackQueuedSpinLock((PKSPIN_LOCK)spin_lock, (PKLOCK_QUEUE_HANDLE)lock_handle);
 }
@@ -43,7 +44,7 @@ _Requires_lock_held_(*lock_handle) _Releases_lock_(*lock_handle) _IRQL_requires_
 _Requires_lock_not_held_(*lock_handle) _Acquires_lock_(*lock_handle) _Post_same_lock_(*spin_lock, *lock_handle)
     _IRQL_requires_max_(DISPATCH_LEVEL) _IRQL_saves_global_(QueuedSpinLock, lock_handle)
         _IRQL_raises_(DISPATCH_LEVEL) void cxplat_acquire_in_stack_queued_spin_lock_at_dpc(
-            _Inout_ cxplat_spin_lock_t* spin_lock, _Out_ cxplat_lock_queue_handle_t* lock_handle)
+            _Inout_ cxplat_queue_spin_lock_t* spin_lock, _Out_ cxplat_lock_queue_handle_t* lock_handle)
 {
     KeAcquireInStackQueuedSpinLockAtDpcLevel((PKSPIN_LOCK)spin_lock, (PKLOCK_QUEUE_HANDLE)lock_handle);
 }
@@ -54,3 +55,45 @@ _Requires_lock_held_(*lock_handle) _Releases_lock_(*lock_handle) _IRQL_requires_
 {
     KeReleaseInStackQueuedSpinLockFromDpcLevel((PKLOCK_QUEUE_HANDLE)lock_handle);
 }
+
+_Requires_lock_not_held_(*spin_lock) _Acquires_lock_(*spin_lock) _IRQL_requires_max_(DISPATCH_LEVEL) _IRQL_saves_
+    _IRQL_raises_(DISPATCH_LEVEL)
+cxplat_irql_t
+cxplat_acquire_spin_lock(_Inout_ cxplat_spin_lock_t* spin_lock)
+{
+    return KeAcquireSpinLockRaiseToDpc((PKSPIN_LOCK)spin_lock);
+}
+
+_Requires_lock_held_(*spin_lock) _Releases_lock_(*spin_lock)
+    _IRQL_requires_(DISPATCH_LEVEL) void cxplat_release_spin_lock(
+        _Inout_ cxplat_spin_lock_t* spin_lock, _In_ _IRQL_restores_ cxplat_irql_t old_irql)
+{
+    KeReleaseSpinLock((PKSPIN_LOCK)spin_lock, old_irql);
+}
+
+_Requires_lock_not_held_(*spin_lock) _Acquires_lock_(*spin_lock) _IRQL_requires_min_(
+    DISPATCH_LEVEL) void cxplat_acquire_spin_lock_at_dpc_level(_Inout_ cxplat_spin_lock_t* spin_lock)
+{
+    KeAcquireSpinLockAtDpcLevel((PKSPIN_LOCK)&spin_lock);
+}
+
+_Requires_lock_held_(*spin_lock) _Releases_lock_(*spin_lock) _IRQL_requires_min_(
+    DISPATCH_LEVEL) void cxplat_release_spin_lock_from_dpc_level(_Inout_ cxplat_spin_lock_t* spin_lock)
+{
+    KeReleaseSpinLockFromDpcLevel((PKSPIN_LOCK)&spin_lock);
+}
+
+_IRQL_requires_max_(HIGH_LEVEL) _IRQL_raises_(irql) _IRQL_saves_ cxplat_irql_t
+    cxplat_raise_irql(_In_ cxplat_irql_t irql)
+{
+    cxplat_irql_t old_irql;
+    KeRaiseIrql(irql, &old_irql);
+    return old_irql;
+}
+
+_IRQL_requires_max_(HIGH_LEVEL) void cxplat_lower_irql(_In_ _Notliteral_ _IRQL_restores_ cxplat_irql_t irql)
+{
+    KeLowerIrql(irql);
+}
+
+_IRQL_requires_max_(HIGH_LEVEL) _IRQL_saves_ cxplat_irql_t cxplat_get_current_irql() { return KeGetCurrentIrql(); }

--- a/cxplat/src/cxplat_winuser/processor_winuser.cpp
+++ b/cxplat/src/cxplat_winuser/processor_winuser.cpp
@@ -99,7 +99,7 @@ cxplat_get_active_processor_count()
 _Requires_lock_not_held_(*lock_handle) _Acquires_lock_(*lock_handle) _Post_same_lock_(*spin_lock, *lock_handle)
     _IRQL_requires_max_(DISPATCH_LEVEL) _IRQL_saves_global_(QueuedSpinLock, lock_handle)
         _IRQL_raises_(DISPATCH_LEVEL) void cxplat_acquire_in_stack_queued_spin_lock(
-            _Inout_ cxplat_spin_lock_t* spin_lock, _Out_ cxplat_lock_queue_handle_t* lock_handle)
+            _Inout_ cxplat_queue_spin_lock_t* spin_lock, _Out_ cxplat_lock_queue_handle_t* lock_handle)
 {
     auto lock = reinterpret_cast<SRWLOCK*>(spin_lock);
     AcquireSRWLockExclusive(lock);
@@ -118,7 +118,7 @@ _Requires_lock_held_(*lock_handle) _Releases_lock_(*lock_handle) _IRQL_requires_
 _Requires_lock_not_held_(*lock_handle) _Acquires_lock_(*lock_handle) _Post_same_lock_(*spin_lock, *lock_handle)
     _IRQL_requires_max_(DISPATCH_LEVEL) _IRQL_saves_global_(QueuedSpinLock, lock_handle)
         _IRQL_raises_(DISPATCH_LEVEL) void cxplat_acquire_in_stack_queued_spin_lock_at_dpc(
-            _Inout_ cxplat_spin_lock_t* spin_lock, _Out_ cxplat_lock_queue_handle_t* lock_handle)
+            _Inout_ cxplat_queue_spin_lock_t* spin_lock, _Out_ cxplat_lock_queue_handle_t* lock_handle)
 {
     auto lock = reinterpret_cast<SRWLOCK*>(spin_lock);
     AcquireSRWLockExclusive(lock);
@@ -133,3 +133,53 @@ _Requires_lock_held_(*lock_handle) _Releases_lock_(*lock_handle) _IRQL_requires_
     auto lock = reinterpret_cast<SRWLOCK*>(lock_handle->Reserved_1[0]);
     ReleaseSRWLockExclusive(lock);
 }
+
+_Requires_lock_not_held_(*spin_lock) _Acquires_lock_(*spin_lock) _IRQL_requires_max_(DISPATCH_LEVEL) _IRQL_saves_
+    _IRQL_raises_(DISPATCH_LEVEL)
+cxplat_irql_t
+cxplat_acquire_spin_lock(_Inout_ cxplat_spin_lock_t* spin_lock)
+{
+    cxplat_irql_t old_irql = cxplat_raise_irql(DISPATCH_LEVEL);
+    auto lock = reinterpret_cast<SRWLOCK*>(spin_lock);
+    AcquireSRWLockExclusive(lock);
+    return old_irql;
+}
+
+_Requires_lock_held_(*spin_lock) _Releases_lock_(*spin_lock)
+    _IRQL_requires_(DISPATCH_LEVEL) void cxplat_release_spin_lock(
+        _Inout_ cxplat_spin_lock_t* spin_lock, _In_ _IRQL_restores_ cxplat_irql_t old_irql)
+{
+    auto lock = reinterpret_cast<SRWLOCK*>(spin_lock);
+    ReleaseSRWLockExclusive(lock);
+    cxplat_lower_irql(old_irql);
+}
+
+_Requires_lock_not_held_(*spin_lock) _Acquires_lock_(*spin_lock) _IRQL_requires_min_(
+    DISPATCH_LEVEL) void cxplat_acquire_spin_lock_at_dpc_level(_Inout_ cxplat_spin_lock_t* spin_lock)
+{
+    auto lock = reinterpret_cast<SRWLOCK*>(spin_lock);
+    AcquireSRWLockExclusive(lock);
+}
+
+_Requires_lock_held_(*spin_lock) _Releases_lock_(*spin_lock) _IRQL_requires_min_(
+    DISPATCH_LEVEL) void cxplat_release_spin_lock_from_dpc_level(_Inout_ cxplat_spin_lock_t* spin_lock)
+{
+    auto lock = reinterpret_cast<SRWLOCK*>(spin_lock);
+}
+
+thread_local cxplat_irql_t _cxplat_current_irql = PASSIVE_LEVEL;
+
+_IRQL_requires_max_(HIGH_LEVEL) _IRQL_raises_(irql) _IRQL_saves_ cxplat_irql_t
+    cxplat_raise_irql(_In_ cxplat_irql_t irql)
+{
+    auto old_irql = _cxplat_current_irql;
+    _cxplat_current_irql = irql;
+    return old_irql;
+}
+
+_IRQL_requires_max_(HIGH_LEVEL) void cxplat_lower_irql(_In_ _Notliteral_ _IRQL_restores_ cxplat_irql_t irql)
+{
+    _cxplat_current_irql = irql;
+}
+
+_IRQL_requires_max_(HIGH_LEVEL) _IRQL_saves_ cxplat_irql_t cxplat_get_current_irql() { return _cxplat_current_irql; }


### PR DESCRIPTION
This pull request includes significant changes to the spin lock implementation and associated tests in the `cxplat` project. The main updates involve renaming and refactoring spin lock types and methods to improve clarity and functionality.

### Spin Lock Refactoring:

* [`cxplat/inc/cxplat_processor.h`](diffhunk://#diff-b86642399b87981cb1bccf6102b366fba25d68cc0169ea2fa1a72e3d0214db61L33-R48): Renamed `cxplat_spin_lock_t` to `cxplat_queue_spin_lock_t` and added new types and methods for `cxplat_spin_lock_t` and `cxplat_irql_t`. [[1]](diffhunk://#diff-b86642399b87981cb1bccf6102b366fba25d68cc0169ea2fa1a72e3d0214db61L33-R48) [[2]](diffhunk://#diff-b86642399b87981cb1bccf6102b366fba25d68cc0169ea2fa1a72e3d0214db61L53-R84)
* [`cxplat/src/cxplat_winkernel/processor_winkernel.c`](diffhunk://#diff-15fdc4b49da9dbb62788c0abd27d50441f344fa3511feda2d60632ea6385f89aL25-R32): Updated spin lock method implementations to use the new `cxplat_spin_lock_t` and `cxplat_irql_t` types. [[1]](diffhunk://#diff-15fdc4b49da9dbb62788c0abd27d50441f344fa3511feda2d60632ea6385f89aL25-R32) [[2]](diffhunk://#diff-15fdc4b49da9dbb62788c0abd27d50441f344fa3511feda2d60632ea6385f89aL46-R47) [[3]](diffhunk://#diff-15fdc4b49da9dbb62788c0abd27d50441f344fa3511feda2d60632ea6385f89aR58-R99)
* [`cxplat/src/cxplat_winuser/processor_winuser.cpp`](diffhunk://#diff-5b4e47699538d34f879d62bbf514e5963bfae8994ec48e0fac8938721f218b79L102-R102): Added new spin lock methods and updated existing ones to use the new `cxplat_spin_lock_t` and `cxplat_irql_t` types. [[1]](diffhunk://#diff-5b4e47699538d34f879d62bbf514e5963bfae8994ec48e0fac8938721f218b79L102-R102) [[2]](diffhunk://#diff-5b4e47699538d34f879d62bbf514e5963bfae8994ec48e0fac8938721f218b79L121-R121) [[3]](diffhunk://#diff-5b4e47699538d34f879d62bbf514e5963bfae8994ec48e0fac8938721f218b79R136-R185)

### Test Case Updates:

* [`cxplat/cxplat_test/cxplat_processor_test.cpp`](diffhunk://#diff-024c622b6c3355b96622f841f830ca4b05dee673f92f8c02b09ac258d042c22bL25-R57): Renamed and added new test cases to cover the updated spin lock functionality.