### PR TITLE
Expose timestamp APIs

### DIFF
--- a/cxplat/cxplat_test/CMakeLists.txt
+++ b/cxplat/cxplat_test/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(cxplat_test
   cxplat_processor_test.cpp
   cxplat_rundown_test.cpp
   cxplat_size_test.cpp
+  cxplat_time_test.cpp
   cxplat_workitem_test.cpp
 )
 

--- a/cxplat/cxplat_test/cxplat_test.vcxproj
+++ b/cxplat/cxplat_test/cxplat_test.vcxproj
@@ -70,6 +70,7 @@
     <ClCompile Include="cxplat_processor_test.cpp" />
     <ClCompile Include="cxplat_rundown_test.cpp" />
     <ClCompile Include="cxplat_size_test.cpp" />
+    <ClCompile Include="cxplat_time_test.cpp" />
     <ClCompile Include="cxplat_workitem_test.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/cxplat/cxplat_test/cxplat_test.vcxproj.filters
+++ b/cxplat/cxplat_test/cxplat_test.vcxproj.filters
@@ -36,5 +36,8 @@
     <ClCompile Include="cxplat_processor_test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="cxplat_time_test.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/cxplat/cxplat_test/cxplat_time_test.cpp
+++ b/cxplat/cxplat_test/cxplat_time_test.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#if !defined(CMAKE_NUGET)
+#include <catch2/catch_all.hpp>
+#else
+#include <catch2/catch.hpp>
+#endif
+#include "cxplat.h"
+
+#include <Windows.h>
+
+TEST_CASE("query_time_precise_include_suspend", "[time]")
+{
+    uint64_t time1 = cxplat_query_time_since_boot_precise(true);
+    Sleep(2);
+    uint64_t time2 = cxplat_query_time_since_boot_precise(true);
+
+    // The time difference should be at least 10000 filetime units (1ms)
+    REQUIRE(time2 - time1 >= 10000);
+}
+
+TEST_CASE("query_time_precise", "[time]")
+{
+    uint64_t time1 = cxplat_query_time_since_boot_precise(false);
+    Sleep(2);
+    uint64_t time2 = cxplat_query_time_since_boot_precise(false);
+
+    // The time difference should be at least 10000 filetime units (1ms)
+    REQUIRE(time2 - time1 >= 10000);
+}
+
+TEST_CASE("query_time_approximate_include_suspend", "[time]")
+{
+    uint64_t time1 = cxplat_query_time_since_boot_approximate(true);
+    Sleep(2);
+    uint64_t time2 = cxplat_query_time_since_boot_approximate(true);
+
+    // The time difference should be at least 10000 filetime units (1ms)
+    REQUIRE(time2 - time1 >= 10000);
+}
+
+TEST_CASE("query_time_approximate", "[time]")
+{
+    uint64_t time1 = cxplat_query_time_since_boot_approximate(false);
+    Sleep(2);
+    uint64_t time2 = cxplat_query_time_since_boot_approximate(false);
+
+    // The time difference should be at least 10000 filetime units (1ms)
+    REQUIRE(time2 - time1 >= 10000);
+}

--- a/cxplat/inc/cxplat.h
+++ b/cxplat/inc/cxplat.h
@@ -7,6 +7,7 @@
 #include "cxplat_processor.h"
 #include "cxplat_rundown.h"
 #include "cxplat_size.h"
+#include "cxplat_time.h"
 #include "cxplat_workitem.h"
 
 CXPLAT_EXTERN_C_BEGIN

--- a/cxplat/inc/cxplat_time.h
+++ b/cxplat/inc/cxplat_time.h
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <stdint.h>
+
+CXPLAT_EXTERN_C_BEGIN
+
+uint64_t
+cxplat_query_time_since_boot_precise(bool include_suspended_time);
+
+uint64_t
+cxplat_query_time_since_boot_approximate(bool include_suspended_time);
+
+CXPLAT_EXTERN_C_END

--- a/cxplat/src/cxplat_winkernel/CMakeLists.txt
+++ b/cxplat/src/cxplat_winkernel/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(cxplat_winkernel STATIC
   memory_winkernel.c
   processor_winkernel.c
   rundown_winkernel.c
+  time_winkernel.c
   workitem_winkernel.c
 )
 

--- a/cxplat/src/cxplat_winkernel/cxplat_winkernel.vcxproj
+++ b/cxplat/src/cxplat_winkernel/cxplat_winkernel.vcxproj
@@ -11,6 +11,7 @@
     <ClCompile Include="processor_winkernel.c" />
     <ClCompile Include="rundown_winkernel.c" />
     <ClCompile Include="size_winkernel.c" />
+    <ClCompile Include="time_winkernel.c" />
     <ClCompile Include="workitem_winkernel.c" />
   </ItemGroup>
   <ItemGroup>

--- a/cxplat/src/cxplat_winkernel/cxplat_winkernel.vcxproj.filters
+++ b/cxplat/src/cxplat_winkernel/cxplat_winkernel.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClCompile Include="processor_winkernel.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="time_winkernel.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\inc\cxplat.h">

--- a/cxplat/src/cxplat_winkernel/time_winkernel.c
+++ b/cxplat/src/cxplat_winkernel/time_winkernel.c
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+#include "cxplat.h"
+#include "wdm.h"
+
+uint64_t
+cxplat_query_time_since_boot_precise(bool include_suspended_time)
+{
+    uint64_t qpc_time;
+    if (include_suspended_time) {
+        // KeQueryUnbiasedInterruptTimePrecise returns the current interrupt-time count in 100-nanosecond units.
+        // Unbiased Interrupt time is the total time since boot including time spent suspended.
+        // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-kequeryunbiasedinterrupttimeprecise
+        return KeQueryUnbiasedInterruptTimePrecise(&qpc_time);
+    } else {
+        // KeQueryInterruptTimePrecise returns the current interrupt-time count in 100-nanosecond units.
+        // (Biased) Interrupt time is the total time since boot excluding time spent suspended.
+        // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-kequeryinterrupttimeprecise
+        return KeQueryInterruptTimePrecise(&qpc_time);
+    }
+}
+
+uint64_t
+cxplat_query_time_since_boot_approximate(bool include_suspended_time)
+{
+    if (include_suspended_time) {
+        // KeQueryUnbiasedInterruptTime returns the current interrupt-time count in 100-nanosecond units.
+        // Unbiased Interrupt time is the total time since boot including time spent suspended.
+        // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-kequeryunbiasedinterrupttime
+        return KeQueryUnbiasedInterruptTime();
+    } else {
+        // KeQueryInterruptTimePrecise returns the current interrupt-time count in 100-nanosecond units.
+        // (Biased) Interrupt time is the total time since boot excluding time spent suspended.
+        // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-kequeryinterrupttime
+        return KeQueryInterruptTime();
+    }
+}

--- a/cxplat/src/cxplat_winuser/CMakeLists.txt
+++ b/cxplat/src/cxplat_winuser/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(cxplat_winuser STATIC
   size_winuser.c
   workitem_winuser.cpp
   symbol_decoder.h
+  time_winuser.cpp
   winuser_internal.h
 )
 

--- a/cxplat/src/cxplat_winuser/cxplat_winuser.vcxproj
+++ b/cxplat/src/cxplat_winuser/cxplat_winuser.vcxproj
@@ -118,6 +118,7 @@
     <ClCompile Include="processor_winuser.cpp" />
     <ClCompile Include="rundown_winuser.cpp" />
     <ClCompile Include="size_winuser.c" />
+    <ClCompile Include="time_winuser.cpp" />
     <ClCompile Include="workitem_winuser.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/cxplat/src/cxplat_winuser/cxplat_winuser.vcxproj.filters
+++ b/cxplat/src/cxplat_winuser/cxplat_winuser.vcxproj.filters
@@ -89,5 +89,8 @@
     <ClCompile Include="processor_winuser.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="time_winuser.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/cxplat/src/cxplat_winuser/time_winuser.cpp
+++ b/cxplat/src/cxplat_winuser/time_winuser.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+#include "cxplat.h"
+#include "realtimeapiset.h"
+
+#pragma comment(lib, "Mincore.lib")
+
+uint64_t
+cxplat_query_time_since_boot_precise(bool include_suspended_time)
+{
+    uint64_t qpc_time;
+    if (include_suspended_time) {
+        // KeQueryUnbiasedInterruptTimePrecise returns the current interrupt-time count in 100-nanosecond units.
+        // Unbiased Interrupt time is the total time since boot including time spent suspended.
+        // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-kequeryunbiasedinterrupttimeprecise
+        QueryUnbiasedInterruptTimePrecise(&qpc_time);
+    } else {
+        // KeQueryInterruptTimePrecise returns the current interrupt-time count in 100-nanosecond units.
+        // (Biased) Interrupt time is the total time since boot excluding time spent suspended.
+        // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-kequeryinterrupttimeprecise
+        QueryInterruptTimePrecise(&qpc_time);
+    }
+    return qpc_time;
+}
+
+uint64_t
+cxplat_query_time_since_boot_approximate(bool include_suspended_time)
+{
+    uint64_t qpc_time;
+    if (include_suspended_time) {
+        // KeQueryUnbiasedInterruptTime returns the current interrupt-time count in 100-nanosecond units.
+        // Unbiased Interrupt time is the total time since boot including time spent suspended.
+        // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-kequeryunbiasedinterrupttime
+        QueryUnbiasedInterruptTime(&qpc_time);
+    } else {
+        // KeQueryInterruptTimePrecise returns the current interrupt-time count in 100-nanosecond units.
+        // (Biased) Interrupt time is the total time since boot excluding time spent suspended.
+        // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-kequeryinterrupttime
+        QueryInterruptTime(&qpc_time);
+    }
+
+    return qpc_time;
+}


### PR DESCRIPTION
This pull request introduces a new feature for time querying in the `cxplat` library, including both precise and approximate time queries with options to include or exclude suspended time. The changes span multiple files to integrate this new functionality.

Key changes include:

### New Time Query Functionality:

* [`cxplat/inc/cxplat_time.h`](diffhunk://#diff-5bec8da9c76b3c132ed6bc37947cd14a525665ae4c69857a032e330be0e79363R1-R15): Added declarations for `cxplat_query_time_since_boot_precise` and `cxplat_query_time_since_boot_approximate` functions.
* [`cxplat/src/cxplat_winkernel/time_winkernel.c`](diffhunk://#diff-d3b578af323f173739b86d8302fa0b991474a991c70d9eec696448528d980656R1-R37): Implemented the time query functions for the winkernel platform.
* [`cxplat/src/cxplat_winuser/time_winuser.cpp`](diffhunk://#diff-34bff65937ca63dcc118ef279a165f22bedb57a38f199e03d1984cd8fd0c6d88R1-R43): Implemented the time query functions for the winuser platform.

### Integration into Build System:

* `cxplat/cxplat_test/CMakeLists.txt`, `cxplat/src/cxplat_winkernel/CMakeLists.txt`, `cxplat/src/cxplat_winuser/CMakeLists.txt`: Added `cxplat_time_test.cpp`, `time_winkernel.c`, and `time_winuser.cpp` to the respective build configurations. [[1]](diffhunk://#diff-8227c30d1f799a5d9ab09a61356f37e9c48e498a472593764ebf0d2f278ddd5cR21) [[2]](diffhunk://#diff-f76065fbef811a9a26ff5211b186551e14f95dc756e478235dcdd27b142945abR16) [[3]](diffhunk://#diff-f045fd64d5ca591a8582c4c3ec5fd9b955131739832f82eabe1548ae69feee35R24)
* `cxplat/cxplat_test/cxplat_test.vcxproj`, `cxplat/src/cxplat_winkernel/cxplat_winkernel.vcxproj`, `cxplat/src/cxplat_winuser/cxplat_winuser.vcxproj`: Updated project files to include new source files for compilation. [[1]](diffhunk://#diff-35ca574a84a5c3a69a8c247a377f4a9a59fa89eb68b65b69a349ef12236fb395R73) [[2]](diffhunk://#diff-694ef7fbe23ed43a03aa00027632467b354d6914bad57aede76364625c939e4bR14) [[3]](diffhunk://#diff-a63fbf82d6f1cd1505fc4ff766182809ff2c09be45f6a66a28fca91b92c301e4R121)

### Test Cases:

* [`cxplat/cxplat_test/cxplat_time_test.cpp`](diffhunk://#diff-48936d311850694af34e223fc128f38d37a3ee6a5fecb9b74904f51c2ad9f6cfR1-R51): Added test cases to verify the new time query functions.

### Header File Updates:

* [`cxplat/inc/cxplat.h`](diffhunk://#diff-2d30f86196912c618020cc4f3182918e53e9e805951b75cdb63f421415d7cbefR10): Included the new `cxplat_time.h` header file.