### PR TITLE
Add support for building against the new WDK 26100

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To use this repository from another project:
    Visual Studio 2022 (v143).
 4. Add a reference from your DLL project to the usersim project and the usersim_dll_skeleton project.
 5. Define `_AMD64_;_WIN32_WINNT=0x0a00` in the project properties preprocessor defines.
-6. Add to AdditionalIncludeDirectories: `$(WindowsSdkDir)Include\10.0.22621.0\km;$(WindowsSdkDir)Include\wdf\kmdf\1.15`
+6. Add to AdditionalIncludeDirectories: `$(WindowsSdkDir)Include\10.0.22621.0\km;$(WindowsSdkDir)Include\10.0.26100.0\km;;$(WindowsSdkDir)Include\wdf\kmdf\1.15`
 7. Disable warning 4324 (structure was padded due to alignment) in the project properties, by adding 4324 to
    Configuration Properties -> C/C++ -> Advanced -> Disable Specific Warnings.
 8. Make sure you are not linking with any kernel libs, since they aren't usable by DLLs.

--- a/cxplat/src/cxplat_winuser/CMakeLists.txt
+++ b/cxplat/src/cxplat_winuser/CMakeLists.txt
@@ -29,6 +29,7 @@ target_include_directories(cxplat_winuser PRIVATE
   "../../inc"
   "../../inc/winuser"
   "${WindowsSdkDir}include/10.0.22621.0"
+  "${WindowsSdkDir}include/10.0.26100.0"
 )
 
 set(defs UNICODE _UNICODE CXPLAT_SOURCE)

--- a/sample/sample.vcxproj
+++ b/sample/sample.vcxproj
@@ -45,7 +45,7 @@
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(WindowsSdkDir)Include\10.0.22621.0\km;$(WindowsSdkDir)Include\wdf\kmdf\1.15;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WindowsSdkDir)Include\10.0.22621.0\km;$(WindowsSdkDir)Include\10.0.26100.0\km;;$(WindowsSdkDir)Include\wdf\kmdf\1.15;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level3</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
@@ -56,7 +56,7 @@
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(WindowsSdkDir)Include\10.0.22621.0\km;$(WindowsSdkDir)Include\wdf\kmdf\1.15;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WindowsSdkDir)Include\10.0.22621.0\km;$(WindowsSdkDir)Include\10.0.26100.0\km;;$(WindowsSdkDir)Include\wdf\kmdf\1.15;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link />
   </ItemDefinitionGroup>

--- a/src/usersim.vcxproj
+++ b/src/usersim.vcxproj
@@ -48,7 +48,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>USERSIM_SOURCE;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\inc;$(ProjectDir)..\cxplat\inc;$(ProjectDir)..\cxplat\inc\winuser;$(WindowsSdkDir)Include\10.0.22621.0\km;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\inc;$(ProjectDir)..\cxplat\inc;$(ProjectDir)..\cxplat\inc\winuser;$(WindowsSdkDir)Include\10.0.22621.0\km;$(WindowsSdkDir)Include\10.0.26100.0\km;;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -63,7 +63,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>USERSIM_SOURCE;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\inc;$(ProjectDir)..\cxplat\inc;$(ProjectDir)..\cxplat\inc\winuser;$(WindowsSdkDir)Include\10.0.22621.0\km;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\inc;$(ProjectDir)..\cxplat\inc;$(ProjectDir)..\cxplat\inc\winuser;$(WindowsSdkDir)Include\10.0.22621.0\km;$(WindowsSdkDir)Include\10.0.26100.0\km;;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -79,7 +79,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>USERSIM_SOURCE;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\inc;$(ProjectDir)..\cxplat\inc;$(ProjectDir)..\cxplat\inc\winuser;$(WindowsSdkDir)Include\10.0.22621.0\km;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\inc;$(ProjectDir)..\cxplat\inc;$(ProjectDir)..\cxplat\inc\winuser;$(WindowsSdkDir)Include\10.0.22621.0\km;$(WindowsSdkDir)Include\10.0.26100.0\km;;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
This pull request includes updates to various project files to reference a new Windows SDK version (10.0.26100.0) in addition to the existing version (10.0.22621.0). The changes ensure that the new SDK paths are included in the project configurations.

Updates to include new Windows SDK version:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R20): Updated the `AdditionalIncludeDirectories` to include `$(WindowsSdkDir)Include0.0.26100.0\km` in the setup instructions.
* [`cxplat/src/cxplat_winuser/CMakeLists.txt`](diffhunk://#diff-f045fd64d5ca591a8582c4c3ec5fd9b955131739832f82eabe1548ae69feee35R32): Added `$(WindowsSdkDir)include/10.0.26100.0` to the `target_include_directories` for the `cxplat_winuser` target.
* [`sample/sample.vcxproj`](diffhunk://#diff-fd921be09f8518155fbd72fae87868d8f742a99d7280d15aa2d734d578e63b39L48-R48): Updated `AdditionalIncludeDirectories` to include `$(WindowsSdkDir)Include0.0.26100.0\km` in two locations. [[1]](diffhunk://#diff-fd921be09f8518155fbd72fae87868d8f742a99d7280d15aa2d734d578e63b39L48-R48) [[2]](diffhunk://#diff-fd921be09f8518155fbd72fae87868d8f742a99d7280d15aa2d734d578e63b39L59-R59)
* [`src/usersim.vcxproj`](diffhunk://#diff-ef27bb4c938df324692a9a12cd49a8392b5f9b270677cdcec2bed28fe6a1fff7L51-R51): Added `$(WindowsSdkDir)Include0.0.26100.0\km` to `AdditionalIncludeDirectories` in three different configurations. [[1]](diffhunk://#diff-ef27bb4c938df324692a9a12cd49a8392b5f9b270677cdcec2bed28fe6a1fff7L51-R51) [[2]](diffhunk://#diff-ef27bb4c938df324692a9a12cd49a8392b5f9b270677cdcec2bed28fe6a1fff7L66-R66) [[3]](diffhunk://#diff-ef27bb4c938df324692a9a12cd49a8392b5f9b270677cdcec2bed28fe6a1fff7L82-R82)