### PR TITLE
Switch to building with WDK nuget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,37 @@ set(CMAKE_SHARED_LINKER_FLAGS_FUZZERDEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG}")
 set(CMAKE_C_FLAGS_FUZZERDEBUG "${CMAKE_C_FLAGS_DEBUG} /fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div /ZH:SHA_256")
 set(CMAKE_CXX_FLAGS_FUZZERDEBUG "${CMAKE_CXX_FLAGS_DEBUG} /fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div /ZH:SHA_256")
 
-# Find and use the WDK for headers
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/external/FindWDK/cmake")
-find_package(WDK REQUIRED)
+# # Find and use the WDK for headers
+# list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/external/FindWDK/cmake")
+# find_package(WDK REQUIRED)
+
+set(NUGET_PACKAGES 
+"Microsoft.Windows.SDK.CPP"
+"Microsoft.Windows.SDK.CPP.arm64"
+"Microsoft.Windows.SDK.CPP.x64"
+"Microsoft.Windows.WDK.ARM64"
+"Microsoft.Windows.WDK.x64"
+)
+
+
+find_program(NUGET nuget)
+if(NOT NUGET)
+  message("ERROR: You must first install nuget.exe from https://www.nuget.org/downloads")
+else()
+  foreach(PACKAGE ${NUGET_PACKAGES})
+    execute_process(COMMAND ${NUGET} install ${PACKAGE} -ExcludeVersion -OutputDirectory ${PROJECT_BINARY_DIR}/packages)
+  endforeach()
+endif()
+
+# Set WDK_ROOT based on the platform (arm64 or x64)
+if (TARGET_PLATFORM STREQUAL "arm64")
+  set(WDK_ROOT "${PROJECT_BINARY_DIR}/packages/Microsoft.Windows.WDK.ARM64/c")
+  set(WDK_VERSION "10.0.26100.0")
+else ()
+set(WDK_ROOT "${PROJECT_BINARY_DIR}/packages/Microsoft.Windows.WDK.x64/c")
+set(WDK_VERSION "10.0.26100.0")
+endif ()
+
 
 # Configure output directories
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${TARGET_PLATFORM}/lib)

--- a/cxplat/cxplat_test/cxplat_test.vcxproj
+++ b/cxplat/cxplat_test/cxplat_test.vcxproj
@@ -6,7 +6,6 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{e356324b-74bb-4123-9fbe-dd8b8ed8658a}</ProjectGuid>
     <RootNamespace>cxplattest</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/cxplat/cxplat_test/cxplat_test.vcxproj
+++ b/cxplat/cxplat_test/cxplat_test.vcxproj
@@ -6,6 +6,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{e356324b-74bb-4123-9fbe-dd8b8ed8658a}</ProjectGuid>
     <RootNamespace>cxplattest</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
@@ -20,6 +21,12 @@
     <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='FuzzerDebug|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='FuzzerDebug|Win32'">
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/cxplat/cxplat_test/cxplat_test.vcxproj
+++ b/cxplat/cxplat_test/cxplat_test.vcxproj
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\wdk.props" />
   <PropertyGroup Label="Globals">
     <VCProjectVersion>17.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{e356324b-74bb-4123-9fbe-dd8b8ed8658a}</ProjectGuid>
     <RootNamespace>cxplattest</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/cxplat/src/cxplat_winkernel/cxplat_winkernel.vcxproj
+++ b/cxplat/src/cxplat_winkernel/cxplat_winkernel.vcxproj
@@ -4,6 +4,7 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\wdk.props" />
   <ItemGroup>
     <ClCompile Include="..\memory.c" />
     <ClCompile Include="cxplat_winkernel.c" />

--- a/cxplat/src/cxplat_winkernel/cxplat_winkernel.vcxproj
+++ b/cxplat/src/cxplat_winkernel/cxplat_winkernel.vcxproj
@@ -37,7 +37,6 @@
     <RootNamespace>cxplatwinkernel</RootNamespace>
     <DriverType>KMDF</DriverType>
     <ProjectName>cxplat_winkernel</ProjectName>
-    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/cxplat/src/cxplat_winkernel/cxplat_winkernel.vcxproj
+++ b/cxplat/src/cxplat_winkernel/cxplat_winkernel.vcxproj
@@ -37,6 +37,7 @@
     <RootNamespace>cxplatwinkernel</RootNamespace>
     <DriverType>KMDF</DriverType>
     <ProjectName>cxplat_winkernel</ProjectName>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/cxplat/src/cxplat_winkernel/packages.config
+++ b/cxplat/src/cxplat_winkernel/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.ARM64" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.x64" version="10.0.26100.2161" targetFramework="native" />
+</packages>

--- a/cxplat/src/cxplat_winuser/cxplat_winuser.vcxproj
+++ b/cxplat/src/cxplat_winuser/cxplat_winuser.vcxproj
@@ -6,7 +6,6 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{f2ca70ab-af9a-47d1-9da9-94d5ab573ac2}</ProjectGuid>
     <RootNamespace>cxplatwinuser</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/cxplat/src/cxplat_winuser/cxplat_winuser.vcxproj
+++ b/cxplat/src/cxplat_winuser/cxplat_winuser.vcxproj
@@ -6,6 +6,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{f2ca70ab-af9a-47d1-9da9-94d5ab573ac2}</ProjectGuid>
     <RootNamespace>cxplatwinuser</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/cxplat/src/cxplat_winuser/cxplat_winuser.vcxproj
+++ b/cxplat/src/cxplat_winuser/cxplat_winuser.vcxproj
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\wdk.props" />
   <PropertyGroup Label="Globals">
     <VCProjectVersion>17.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{f2ca70ab-af9a-47d1-9da9-94d5ab573ac2}</ProjectGuid>
     <RootNamespace>cxplatwinuser</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.arm64" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.ARM64" version="10.0.26100.2161" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.x64" version="10.0.26100.2161" targetFramework="native" />
+</packages>

--- a/sample/sample.vcxproj
+++ b/sample/sample.vcxproj
@@ -8,7 +8,6 @@
     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration>Debug</Configuration>
     <RootNamespace>sample</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/sample/sample.vcxproj
+++ b/sample/sample.vcxproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\wdk.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C0640FCB-27E2-4C37-82C4-06B479C69F1F}</ProjectGuid>
     <TemplateGuid>{1bc93793-694f-48fe-9372-81e2b05556fd}</TemplateGuid>
@@ -7,7 +8,7 @@
     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration>Debug</Configuration>
     <RootNamespace>sample</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
@@ -45,7 +46,7 @@
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(WindowsSdkDir)Include\10.0.22621.0\km;$(WindowsSdkDir)Include\10.0.26100.0\km;;$(WindowsSdkDir)Include\wdf\kmdf\1.15;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WdkContentRoot)\Include\10.0.26100.0\km;$(WdkContentRoot)\Include\wdf\kmdf\1.15;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level3</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
@@ -56,7 +57,7 @@
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(WindowsSdkDir)Include\10.0.22621.0\km;$(WindowsSdkDir)Include\10.0.26100.0\km;;$(WindowsSdkDir)Include\wdf\kmdf\1.15;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WdkContentRoot)\Include\10.0.26100.0\km;$(WdkContentRoot)\Include\wdf\kmdf\1.15;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link />
   </ItemDefinitionGroup>

--- a/sample/sample.vcxproj
+++ b/sample/sample.vcxproj
@@ -8,6 +8,7 @@
     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration>Debug</Configuration>
     <RootNamespace>sample</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/setup_build/setup_build.vcxproj
+++ b/setup_build/setup_build.vcxproj
@@ -10,7 +10,6 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{bfb0c59a-3f15-4d80-a65f-9a9a6dca3334}</ProjectGuid>
     <RootNamespace>setupbuild</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/setup_build/setup_build.vcxproj
+++ b/setup_build/setup_build.vcxproj
@@ -10,6 +10,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{bfb0c59a-3f15-4d80-a65f-9a9a6dca3334}</ProjectGuid>
     <RootNamespace>setupbuild</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/setup_build/setup_build.vcxproj
+++ b/setup_build/setup_build.vcxproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\wdk.props" />
   <ItemGroup>
     <None Include="..\scripts\git_hooks\commit-msg" />
     <None Include="..\scripts\git_hooks\pre-commit" />
@@ -9,7 +10,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{bfb0c59a-3f15-4d80-a65f-9a9a6dca3334}</ProjectGuid>
     <RootNamespace>setupbuild</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/src/framework.h
+++ b/src/framework.h
@@ -22,7 +22,7 @@ typedef NTSTATUS* PNTSTATUS;
 #define NT_SUCCESS(status) (((NTSTATUS)(status)) >= 0)
 #include "kernel_um.h"
 
-#include <../km/netioddk.h>
+#include <netioddk.h>
 #include <netiodef.h>
 #define STATUS_NOINTERFACE ((NTSTATUS)0xC00002B9L)
 #include "cxplat.h"

--- a/src/usersim.vcxproj
+++ b/src/usersim.vcxproj
@@ -6,6 +6,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{030a7ac6-14dc-45cf-af34-891057ab1402}</ProjectGuid>
     <RootNamespace>usersim</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/src/usersim.vcxproj
+++ b/src/usersim.vcxproj
@@ -6,7 +6,6 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{030a7ac6-14dc-45cf-af34-891057ab1402}</ProjectGuid>
     <RootNamespace>usersim</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/src/usersim.vcxproj
+++ b/src/usersim.vcxproj
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\wdk.props" />
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{030a7ac6-14dc-45cf-af34-891057ab1402}</ProjectGuid>
     <RootNamespace>usersim</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
@@ -48,7 +49,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>USERSIM_SOURCE;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\inc;$(ProjectDir)..\cxplat\inc;$(ProjectDir)..\cxplat\inc\winuser;$(WindowsSdkDir)Include\10.0.22621.0\km;$(WindowsSdkDir)Include\10.0.26100.0\km;;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\inc;$(ProjectDir)..\cxplat\inc;$(ProjectDir)..\cxplat\inc\winuser;$(WdkContentRoot)\Include\10.0.26100.0\km</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -79,7 +80,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>USERSIM_SOURCE;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\inc;$(ProjectDir)..\cxplat\inc;$(ProjectDir)..\cxplat\inc\winuser;$(WindowsSdkDir)Include\10.0.22621.0\km;$(WindowsSdkDir)Include\10.0.26100.0\km;;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\inc;$(ProjectDir)..\cxplat\inc;$(ProjectDir)..\cxplat\inc\winuser;$(WdkContentRoot)\Include\10.0.26100.0\km</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/tests/tests.vcxproj
+++ b/tests/tests.vcxproj
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\wdk.props" />
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{c7b63ca3-a0b8-4ee3-85c8-a17cb40440bf}</ProjectGuid>
     <RootNamespace>tests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
@@ -42,7 +43,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\external\catch2\src;$(ProjectDir)..\external\catch2\build\generated-includes;$(ProjectDir)..\inc;$(SolutionDir)cxplat\inc;$(SolutionDir)cxplat\inc\winuser;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\external\catch2\src;$(ProjectDir)..\external\catch2\build\generated-includes;$(ProjectDir)..\inc;$(SolutionDir)cxplat\inc;$(SolutionDir)cxplat\inc\winuser;$(WdkContentRoot)\Include\10.0.26100.0\km;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -59,7 +60,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\external\catch2\src;$(ProjectDir)..\external\catch2\build\generated-includes;$(ProjectDir)..\inc;$(SolutionDir)cxplat\inc;$(SolutionDir)cxplat\inc\winuser;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\external\catch2\src;$(ProjectDir)..\external\catch2\build\generated-includes;$(ProjectDir)..\inc;$(SolutionDir)cxplat\inc;$(SolutionDir)cxplat\inc\winuser;$(WdkContentRoot)\Include\10.0.26100.0\km;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/tests/tests.vcxproj
+++ b/tests/tests.vcxproj
@@ -6,7 +6,6 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{c7b63ca3-a0b8-4ee3-85c8-a17cb40440bf}</ProjectGuid>
     <RootNamespace>tests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/tests/tests.vcxproj
+++ b/tests/tests.vcxproj
@@ -6,6 +6,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{c7b63ca3-a0b8-4ee3-85c8-a17cb40440bf}</ProjectGuid>
     <RootNamespace>tests</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/usersim_dll_skeleton/usersim_dll_skeleton.vcxproj
+++ b/usersim_dll_skeleton/usersim_dll_skeleton.vcxproj
@@ -12,6 +12,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{1937db41-f3eb-4955-a636-6386dcb394f6}</ProjectGuid>
     <RootNamespace>usersimdllskeleton</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/usersim_dll_skeleton/usersim_dll_skeleton.vcxproj
+++ b/usersim_dll_skeleton/usersim_dll_skeleton.vcxproj
@@ -1,14 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\wdk.props" />
   <ItemGroup>
     <ClCompile Include="dll_skeleton.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{1937db41-f3eb-4955-a636-6386dcb394f6}</ProjectGuid>
     <RootNamespace>usersimdllskeleton</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
@@ -41,7 +45,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\inc;$(ProjectDir)..\cxplat\inc;$(ProjectDir)..\cxplat\inc\winuser</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\inc;$(ProjectDir)..\cxplat\inc;$(ProjectDir)..\cxplat\inc\winuser;$(WdkContentRoot)\Include\10.0.26100.0\km</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -57,7 +61,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\inc;$(ProjectDir)..\cxplat\inc;$(ProjectDir)..\cxplat\inc\winuser</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\inc;$(ProjectDir)..\cxplat\inc;$(ProjectDir)..\cxplat\inc\winuser;$(WdkContentRoot)\Include\10.0.26100.0\km</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>

--- a/usersim_dll_skeleton/usersim_dll_skeleton.vcxproj
+++ b/usersim_dll_skeleton/usersim_dll_skeleton.vcxproj
@@ -12,7 +12,6 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{1937db41-f3eb-4955-a636-6386dcb394f6}</ProjectGuid>
     <RootNamespace>usersimdllskeleton</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">

--- a/usersim_dll_skeleton/usersim_dll_skeleton.vcxproj.filters
+++ b/usersim_dll_skeleton/usersim_dll_skeleton.vcxproj.filters
@@ -19,4 +19,7 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/wdk.props
+++ b/wdk.props
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation
+  SPDX-License-Identifier: MIT
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="Platform">
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.10.0.26100.2161\build\native\Microsoft.Windows.SDK.cpp.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.10.0.26100.2161\build\native\Microsoft.Windows.SDK.cpp.props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.WDK.x64.10.0.26100.2161\build\native\Microsoft.Windows.WDK.x64.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.WDK.x64.10.0.26100.2161\build\native\Microsoft.Windows.WDK.x64.props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.2161\build\native\Microsoft.Windows.SDK.cpp.x64.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.2161\build\native\Microsoft.Windows.SDK.cpp.x64.props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.WDK.ARM64.10.0.26100.2161\build\native\Microsoft.Windows.WDK.arm64.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.WDK.ARM64.10.0.26100.2161\build\native\Microsoft.Windows.WDK.arm64.props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.arm64.10.0.26100.2161\build\native\Microsoft.Windows.SDK.cpp.arm64.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.arm64.10.0.26100.2161\build\native\Microsoft.Windows.SDK.cpp.arm64.props')" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.10.0.26100.2161\build\native\Microsoft.Windows.SDK.cpp.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.10.0.26100.2161\build\native\Microsoft.Windows.SDK.cpp.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.10.0.26100.2161\build\native\Microsoft.Windows.SDK.cpp.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.10.0.26100.2161\build\native\Microsoft.Windows.SDK.cpp.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.10.0.26100.2161\build\native\Microsoft.Windows.SDK.cpp.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.10.0.26100.2161\build\native\Microsoft.Windows.SDK.cpp.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.2161\build\native\Microsoft.Windows.SDK.cpp.x64.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.2161\build\native\Microsoft.Windows.SDK.cpp.x64.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.WDK.x64.10.0.26100.2161\build\native\Microsoft.Windows.WDK.x64.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.WDK.x64.10.0.26100.2161\build\native\Microsoft.Windows.WDK.x64.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.arm64.10.0.26100.2161\build\native\Microsoft.Windows.SDK.cpp.arm64.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.arm64.10.0.26100.2161\build\native\Microsoft.Windows.SDK.cpp.arm64.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.WDK.ARM64.10.0.26100.2161\build\native\Microsoft.Windows.WDK.arm64.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.WDK.ARM64.10.0.26100.2161\build\native\Microsoft.Windows.WDK.arm64.props'))" />
+  </Target>
+</Project>


### PR DESCRIPTION
This pull request includes several updates to the project configuration files to integrate and utilize the Windows Driver Kit (WDK) and the Windows SDK via NuGet packages. The main changes involve modifying the project files to import a new `wdk.props` file, updating the Windows Target Platform Version, and adjusting include directories.

Key changes include:

### Integration of WDK and Windows SDK via NuGet:

* **`CMakeLists.txt`:** Added logic to install required NuGet packages for WDK and Windows SDK and set the `WDK_ROOT` based on the platform (arm64 or x64).
* **`wdk.props`:** Added a new file to import the necessary properties and targets from the installed NuGet packages.
* **Project Files:** Updated various project files (`.vcxproj`) to import the `wdk.props` file and set the Windows Target Platform Version to `10.0.26100.0`. This includes:
  - `cxplat_test.vcxproj`
  - `cxplat_winkernel.vcxproj`
  - `cxplat_winuser.vcxproj`
  - `sample.vcxproj`
  - `setup_build.vcxproj`
  - `usersim.vcxproj`
  - `tests.vcxproj`
  - `usersim_dll_skeleton.vcxproj`

### Update of Include Directories:

* **Include Directories:** Adjusted the `AdditionalIncludeDirectories` in various project files to use the new WDK and SDK directories from the NuGet packages. This includes:
  - `sample.vcxproj` [[1]](diffhunk://#diff-fd921be09f8518155fbd72fae87868d8f742a99d7280d15aa2d734d578e63b39L48-R49) [[2]](diffhunk://#diff-fd921be09f8518155fbd72fae87868d8f742a99d7280d15aa2d734d578e63b39L59-R60)
  - `usersim.vcxproj` [[1]](diffhunk://#diff-ef27bb4c938df324692a9a12cd49a8392b5f9b270677cdcec2bed28fe6a1fff7L51-R52) [[2]](diffhunk://#diff-ef27bb4c938df324692a9a12cd49a8392b5f9b270677cdcec2bed28fe6a1fff7L82-R83)
  - `tests.vcxproj` [[1]](diffhunk://#diff-b8ea2d22c2bd24b764ec735e47f3a2810fc5d6831e5aa2772223a0ca15f7781fL45-R46) [[2]](diffhunk://#diff-b8ea2d22c2bd24b764ec735e47f3a2810fc5d6831e5aa2772223a0ca15f7781fL62-R63)
  - `usersim_dll_skeleton.vcxproj` [[1]](diffhunk://#diff-e08c2de7af0c43970f404762b3cd9be69d94d40f946b730ec65e4b48b0578f70L44-R48) [[2]](diffhunk://#diff-e08c2de7af0c43970f404762b3cd9be69d94d40f946b730ec65e4b48b0578f70L60-R64)

### Minor Code Adjustments:

* **`framework.h`:** Updated the include path for `netioddk.h` to remove the relative path.

These changes ensure that the project is correctly configured to use the latest versions of the WDK and Windows SDK, improving compatibility and maintainability.