### PR TITLE
Fix paths in fuzzerdebug

### DIFF
--- a/src/usersim.vcxproj
+++ b/src/usersim.vcxproj
@@ -64,7 +64,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>USERSIM_SOURCE;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\inc;$(ProjectDir)..\cxplat\inc;$(ProjectDir)..\cxplat\inc\winuser;$(WindowsSdkDir)Include\10.0.22621.0\km;$(WindowsSdkDir)Include\10.0.26100.0\km;;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\inc;$(ProjectDir)..\cxplat\inc;$(ProjectDir)..\cxplat\inc\winuser;$(WdkContentRoot)\Include\10.0.26100.0\km</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
This pull request includes a modification to the `src/usersim.vcxproj` file to update the include directories.

Changes in include directories:

* [`src/usersim.vcxproj`](diffhunk://#diff-ef27bb4c938df324692a9a12cd49a8392b5f9b270677cdcec2bed28fe6a1fff7L67-R67): Updated the `AdditionalIncludeDirectories` to use `$(WdkContentRoot)` instead of `$(WindowsSdkDir)` for the `10.0.26100.0\km` directory. This change ensures that the correct directories are referenced for the project.