### PR TITLE
Fix cxplat_release_spin_lock_from_dpc_level

### DIFF
--- a/cxplat/src/cxplat_winuser/processor_winuser.cpp
+++ b/cxplat/src/cxplat_winuser/processor_winuser.cpp
@@ -165,6 +165,7 @@ _Requires_lock_held_(*spin_lock) _Releases_lock_(*spin_lock) _IRQL_requires_min_
     DISPATCH_LEVEL) void cxplat_release_spin_lock_from_dpc_level(_Inout_ cxplat_spin_lock_t* spin_lock)
 {
     auto lock = reinterpret_cast<SRWLOCK*>(spin_lock);
+    ReleaseSRWLockExclusive(lock);
 }
 
 thread_local cxplat_irql_t _cxplat_current_irql = PASSIVE_LEVEL;


### PR DESCRIPTION
This pull request includes a small change to the `cxplat/src/cxplat_winuser/processor_winuser.cpp` file. The change ensures that the `ReleaseSRWLockExclusive` function is called when releasing a spin lock at the DPC level.

* [`cxplat/src/cxplat_winuser/processor_winuser.cpp`](diffhunk://#diff-5b4e47699538d34f879d62bbf514e5963bfae8994ec48e0fac8938721f218b79R168): Added a call to `ReleaseSRWLockExclusive` in the `cxplat_release_spin_lock_from_dpc_level` function to properly release the spin lock.