### PR TITLE
Add group affinity

### DIFF
--- a/inc/usersim/ke.h
+++ b/inc/usersim/ke.h
@@ -90,12 +90,12 @@ void
 usersim_clean_up_irql();
 
 USERSIM_API
-void
-usersim_set_affinity_and_priority_override(uint32_t processor_index);
+bool
+usersim_set_current_thread_priority(int priority, int* old_priority);
 
 USERSIM_API
-void
-usersim_clear_affinity_and_priority_override();
+bool
+usersim_set_current_thread_affinity(const GROUP_AFFINITY* new_affinity, GROUP_AFFINITY* old_affinity);
 
 #pragma endregion irqls
 

--- a/src/ke.cpp
+++ b/src/ke.cpp
@@ -363,7 +363,7 @@ KeSetSystemAffinityThreadEx(KAFFINITY affinity)
     } else {
         bool result = usersim_set_current_thread_affinity(&new_affinity, &old_affinity);
         if (result) {
-            return (KAFFINITY)old_affinity.Mask;
+            return old_affinity.Mask;
         } else {
             return 0;
         }
@@ -392,7 +392,12 @@ KeSetSystemGroupAffinityThread(_In_ const PGROUP_AFFINITY Affinity, _Out_opt_ PG
 void
 KeRevertToUserGroupAffinityThread(PGROUP_AFFINITY PreviousAffinity)
 {
-    (void)usersim_set_current_thread_affinity(PreviousAffinity, nullptr);
+    bool result = usersim_set_current_thread_affinity(PreviousAffinity, nullptr);
+#if defined(NDEBUG)
+    UNREFERENCED_PARAMETER(result);
+#else
+    assert(result);
+#endif
 }
 
 PKTHREAD
@@ -654,10 +659,10 @@ class _usersim_emulated_dpc
 
                         l.unlock();
                         _usersim_dispatch_locks[i].lock();
-                        //_usersim_current_irql = DISPATCH_LEVEL;
+                        _usersim_current_irql = DISPATCH_LEVEL;
                         work_item->work_item_routine(work_item, context, parameter_1, parameter_2);
                         _usersim_dispatch_locks[i].unlock();
-                        //_usersim_current_irql = PASSIVE_LEVEL;
+                        _usersim_current_irql = PASSIVE_LEVEL;
                         l.lock();
                     }
                 }

--- a/src/ke.cpp
+++ b/src/ke.cpp
@@ -151,6 +151,7 @@ usersim_set_current_thread_priority(int priority, int* old_priority)
  * @return true Success.
  * @return false Failure.
  */
+USERSIM_API
 bool
 usersim_set_current_thread_affinity(const GROUP_AFFINITY* new_affinity, GROUP_AFFINITY* old_affinity)
 {
@@ -194,7 +195,7 @@ _get_irql_thread_priority(KIRQL irql)
 inline BOOL
 _set_current_thread_priority_by_irql(KIRQL new_irql)
 {
-    if (new_irql > DISPATCH_LEVEL) {
+    if (new_irql >= DISPATCH_LEVEL) {
         return usersim_set_current_thread_priority(
             _get_irql_thread_priority(new_irql), &_usersim_thread_priority_before_raise_irql);
     } else {

--- a/src/platform.h
+++ b/src/platform.h
@@ -426,12 +426,6 @@ usersim_random_uint32();
 uint64_t
 usersim_query_time_since_boot(bool include_suspended_time);
 
-_Must_inspect_result_ bool
-usersim_set_current_thread_affinity(const GROUP_AFFINITY* new_affinity, GROUP_AFFINITY* old_affinity);
-
-void
-usersim_restore_current_thread_affinity(GROUP_AFFINITY* old_affinity);
-
 typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 
 /**

--- a/src/platform.h
+++ b/src/platform.h
@@ -426,11 +426,11 @@ usersim_random_uint32();
 uint64_t
 usersim_query_time_since_boot(bool include_suspended_time);
 
-_Must_inspect_result_ usersim_result_t
-usersim_set_current_thread_affinity(uintptr_t new_thread_affinity_mask, _Out_ uintptr_t* old_thread_affinity_mask);
+_Must_inspect_result_ bool
+usersim_set_current_thread_affinity(const GROUP_AFFINITY* new_affinity, GROUP_AFFINITY* old_affinity);
 
 void
-usersim_restore_current_thread_affinity(uintptr_t old_thread_affinity_mask);
+usersim_restore_current_thread_affinity(GROUP_AFFINITY* old_affinity);
 
 typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 

--- a/tests/ke_test.cpp
+++ b/tests/ke_test.cpp
@@ -177,11 +177,12 @@ TEST_CASE("threads", "[ke]")
 
     KAFFINITY new_affinity = ((ULONG_PTR)1 << processor_count) - 1;
     KAFFINITY old_affinity = KeSetSystemAffinityThreadEx(new_affinity);
-    REQUIRE(old_affinity != 0);
+    // No old affinity was set.
+    REQUIRE(old_affinity == 0);
 
     KeRevertToUserAffinityThreadEx(old_affinity);
 
-     for (ULONG i = 0; i < processor_count; i++) {
+    for (ULONG i = 0; i < processor_count; i++) {
         PROCESSOR_NUMBER processor_number = {};
         GROUP_AFFINITY old_group_affinity = {};
         GROUP_AFFINITY new_group_affinity = {};

--- a/tests/ke_test.cpp
+++ b/tests/ke_test.cpp
@@ -40,8 +40,6 @@ TEST_CASE("irql", "[ke]")
 
 TEST_CASE("irql_perf_override", "[ke]")
 {
-    usersim_set_affinity_and_priority_override(0);
-
     REQUIRE(KeGetCurrentIrql() == PASSIVE_LEVEL);
 
     KIRQL old_irql;
@@ -65,8 +63,6 @@ TEST_CASE("irql_perf_override", "[ke]")
 
     KeLowerIrql(old_irql);
     REQUIRE(KeGetCurrentIrql() == PASSIVE_LEVEL);
-
-    usersim_clear_affinity_and_priority_override();
 }
 
 TEST_CASE("KfRaiseIrql", "[ke]")


### PR DESCRIPTION
This pull request includes several changes to the `usersim` module, focusing on improving thread priority and affinity management. The changes involve replacing existing functions with new ones that cache thread priority and affinity to optimize performance.

### Key Changes:

#### Thread Priority and Affinity Management:
* Replaced `usersim_set_affinity_and_priority_override` and `usersim_clear_affinity_and_priority_override` with `usersim_set_current_thread_priority` and `usersim_set_current_thread_affinity` functions to manage thread priority and affinity more efficiently by caching values. [[1]](diffhunk://#diff-b8dcb37bfb713c012fcd5f680d7c8d09631115092cca187a2bb90707b9c8154eL93-R98) [[2]](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bR116-R180)
* Introduced new thread-local variables to cache thread priority and affinity, replacing the previous override mechanism.
* Updated various functions to use the new `usersim_set_current_thread_priority` and `usersim_set_current_thread_affinity` functions, ensuring thread priority and affinity are set only when necessary. [[1]](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bL128-L176) [[2]](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bL198-L204) [[3]](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bL226-L232) [[4]](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bR355-R370) [[5]](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bL359-R382) [[6]](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bL372-L394)

#### Code Cleanup:
* Removed the old `usersim_get_current_thread_group_affinity` function and related affinity management functions that are no longer needed. [[1]](diffhunk://#diff-6bf312c06fbab586948463c7433568611f84ae80d29800727d16a4eaa227685bL372-L394) [[2]](diffhunk://#diff-c2d906a1d52816e42e57c6e6c0ad9e0483b02f8df6cd2d03f6d23ebc748fce9fL429-L434)

#### Tests:
* Updated tests to reflect the removal of the old affinity and priority override functions and to validate the new behavior. [[1]](diffhunk://#diff-afb8ded167839a6afd7a23e57a4b8611013e46c6de2f8522992e316bd13ba081L43-L44) [[2]](diffhunk://#diff-afb8ded167839a6afd7a23e57a4b8611013e46c6de2f8522992e316bd13ba081L68-L69) [[3]](diffhunk://#diff-afb8ded167839a6afd7a23e57a4b8611013e46c6de2f8522992e316bd13ba081L184-R181)