### PR TITLE
Use correct tag when allocating utf8

### DIFF
--- a/cxplat/src/cxplat_winkernel/module_winkernel.c
+++ b/cxplat/src/cxplat_winkernel/module_winkernel.c
@@ -30,7 +30,7 @@ cxplat_convert_ansi_to_utf8_string(_In_ ANSI_STRING* ansi_string, _Out_ cxplat_u
 
     // Allocate the UTF-8 string large enough to hold the converted string and a null terminator.
     utf8->length = utf8_str.Length + 1; // +1 for null terminator
-    utf8->value = cxplat_allocate(CXPLAT_POOL_FLAG_NON_PAGED, utf8->length, CXPLAT_TAG_STRING);
+    utf8->value = cxplat_allocate(CXPLAT_POOL_FLAG_NON_PAGED, utf8->length, CXPLAT_TAG_UTF8_STRING);
     if (utf8->value == NULL) {
         cxplat_status = CXPLAT_STATUS_NO_MEMORY;
         goto Exit;

--- a/cxplat/src/cxplat_winuser/module_winuser.cpp
+++ b/cxplat/src/cxplat_winuser/module_winuser.cpp
@@ -40,7 +40,7 @@ cxplat_get_module_path_from_address(_In_ const void* address, _Out_ cxplat_utf8_
 
     // Allocate the UTF-8 string large enough to hold the converted string and a null terminator.
     utf8_path->length = utf8_length + 1; // +1 for null terminator
-    utf8_path->value = (uint8_t*)cxplat_allocate(CXPLAT_POOL_FLAG_NON_PAGED, utf8_path->length, CXPLAT_TAG_STRING);
+    utf8_path->value = (uint8_t*)cxplat_allocate(CXPLAT_POOL_FLAG_NON_PAGED, utf8_path->length, CXPLAT_TAG_UTF8_STRING);
     if (utf8_path->value == NULL) {
         status = CXPLAT_STATUS_NO_MEMORY;
         goto Done;


### PR DESCRIPTION
The function cxplat_get_module_path_from_address incorrectly allocated memory for a utf-8 string using the CXPLAT_TAG_STRING tag instead of the CXPLAT_TAG_UTF8_STRING tag.
