### PR TITLE
Add SeReleaseSubjectContext

### DIFF
--- a/inc/usersim/se.h
+++ b/inc/usersim/se.h
@@ -140,6 +140,10 @@ SeCaptureSubjectContext(_Out_ PSECURITY_SUBJECT_CONTEXT subject_context);
 
 USERSIM_API
 VOID
+SeReleaseSubjectContext(_Inout_ PSECURITY_SUBJECT_CONTEXT SubjectContext);
+
+USERSIM_API
+VOID
 SeLockSubjectContext(_In_ PSECURITY_SUBJECT_CONTEXT subject_context);
 
 USERSIM_API

--- a/src/se.cpp
+++ b/src/se.cpp
@@ -110,6 +110,13 @@ SeUnlockSubjectContext(_In_ PSECURITY_SUBJECT_CONTEXT subject_context)
     }
 }
 
+VOID
+SeReleaseSubjectContext(_In_ PSECURITY_SUBJECT_CONTEXT subject_context)
+{
+    UNREFERENCED_PARAMETER(subject_context);
+    // This function is a no-op in usersim.
+}
+
 _IRQL_requires_max_(PASSIVE_LEVEL) USERSIM_API BOOLEAN SeAccessCheck(
     _In_ PSECURITY_DESCRIPTOR security_descriptor,
     _In_ PSECURITY_SUBJECT_CONTEXT subject_security_context,


### PR DESCRIPTION
This pull request introduces a new function, `SeReleaseSubjectContext`, to the `USERSIM_API`. The function is implemented as a no-op in the `usersim` environment, ensuring compatibility while maintaining clarity in the API.

### Additions to the `USERSIM_API`:

* [`inc/usersim/se.h`](diffhunk://#diff-d58599c2c0b9a9264f996f6f08ec6ecb6452d8173c627102eaef921e41b47ee3R141-R144): Declared the new function `SeReleaseSubjectContext`, which takes a `_Inout_ PSECURITY_SUBJECT_CONTEXT` parameter.

### Implementation details:

* [`src/se.cpp`](diffhunk://#diff-82d9ecffbce55573777f8612cec818bb4cd306b8f7abe113ce64988bc3043aa2R113-R119): Implemented `SeReleaseSubjectContext` as a no-op function, with the parameter marked as `UNREFERENCED`. This ensures the function exists without performing any operations in the `usersim` environment.