### PR TITLE
Add test apis to remove flow context in sock ops.

### DIFF
--- a/inc/usersim/fwp_test.h
+++ b/inc/usersim/fwp_test.h
@@ -59,4 +59,7 @@ usersim_fwp_set_sublayer_guids(
 USERSIM_API void
 usersim_fwp_sock_ops_v4_remove_flow_context(uint64_t flow_id);
 
+USERSIM_API void
+usersim_fwp_sock_ops_v6_remove_flow_context(uint64_t flow_id);
+
 CXPLAT_EXTERN_C_END

--- a/inc/usersim/fwp_test.h
+++ b/inc/usersim/fwp_test.h
@@ -47,13 +47,16 @@ USERSIM_API FWP_ACTION_TYPE
 usersim_fwp_cgroup_inet6_connect(_In_ fwp_classify_parameters_t* parameters);
 
 USERSIM_API FWP_ACTION_TYPE
-usersim_fwp_sock_ops_v4(_In_ fwp_classify_parameters_t* parameters);
+usersim_fwp_sock_ops_v4(_In_ fwp_classify_parameters_t* parameters, _Out_ uint64_t* flow_id);
 
 USERSIM_API FWP_ACTION_TYPE
-usersim_fwp_sock_ops_v6(_In_ fwp_classify_parameters_t* parameters);
+usersim_fwp_sock_ops_v6(_In_ fwp_classify_parameters_t* parameters, _Out_ uint64_t* flow_id);
 
 USERSIM_API void
 usersim_fwp_set_sublayer_guids(
     _In_ const GUID& default_sublayer, _In_ const GUID& connect_v4_sublayer, _In_ const GUID& connect_v6_sublayer);
+
+USERSIM_API void
+usersim_fwp_sock_ops_v4_remove_flow_context(uint64_t flow_id);
 
 CXPLAT_EXTERN_C_END

--- a/src/fwp_um.cpp
+++ b/src/fwp_um.cpp
@@ -203,6 +203,11 @@ void fwp_engine_t::test_sock_ops_v4_remove_flow_context(uint64_t flow_id)
     test_remove_flow_context(flow_id, FWPS_LAYER_ALE_FLOW_ESTABLISHED_V4, FWPM_LAYER_ALE_FLOW_ESTABLISHED_V4);
 }
 
+void fwp_engine_t::test_sock_ops_v6_remove_flow_context(uint64_t flow_id)
+{
+    test_remove_flow_context(flow_id, FWPS_LAYER_ALE_FLOW_ESTABLISHED_V6, FWPM_LAYER_ALE_FLOW_ESTABLISHED_V6);
+}
+
 _Requires_lock_not_held_(this->lock) void fwp_engine_t::test_remove_flow_context(
     uint64_t flow_id,
     uint16_t layer_id,
@@ -1031,6 +1036,13 @@ usersim_fwp_sock_ops_v4_remove_flow_context(
    uint64_t flow_id)
 {
     fwp_engine_t::get()->test_sock_ops_v4_remove_flow_context(flow_id);
+}
+
+void
+usersim_fwp_sock_ops_v6_remove_flow_context(
+   uint64_t flow_id)
+{
+    fwp_engine_t::get()->test_sock_ops_v6_remove_flow_context(flow_id);
 }
 
 #pragma endregion test_fwp

--- a/src/fwp_um.h
+++ b/src/fwp_um.h
@@ -238,7 +238,11 @@ typedef class fwp_engine_t
     FWP_ACTION_TYPE
     test_sock_ops_v6(_In_ fwp_classify_parameters_t* parameters, _Out_ uint64_t* flow_id);
 
-    void test_sock_ops_v4_remove_flow_context(uint64_t flow_id);
+    void 
+    test_sock_ops_v4_remove_flow_context(uint64_t flow_id);
+
+    void 
+    test_sock_ops_v6_remove_flow_context(uint64_t flow_id);
 
     static fwp_engine_t*
     get()

--- a/src/fwp_um.h
+++ b/src/fwp_um.h
@@ -233,10 +233,12 @@ typedef class fwp_engine_t
     test_cgroup_inet6_connect(_In_ fwp_classify_parameters_t* parameters);
 
     FWP_ACTION_TYPE
-    test_sock_ops_v4(_In_ fwp_classify_parameters_t* parameters);
+    test_sock_ops_v4(_In_ fwp_classify_parameters_t* parameters, _Out_ uint64_t* flow_id);
 
     FWP_ACTION_TYPE
-    test_sock_ops_v6(_In_ fwp_classify_parameters_t* parameters);
+    test_sock_ops_v6(_In_ fwp_classify_parameters_t* parameters, _Out_ uint64_t* flow_id);
+
+    void test_sock_ops_v4_remove_flow_context(uint64_t flow_id);
 
     static fwp_engine_t*
     get()
@@ -252,7 +254,13 @@ typedef class fwp_engine_t
         uint16_t layer_id,
         _In_ const GUID& layer_guid,
         _In_ const GUID& sublayer_guid,
-        _In_ FWPS_INCOMING_VALUE0* incoming_value);
+        _In_ FWPS_INCOMING_VALUE0* incoming_value,
+        _Out_opt_ uint64_t* flow_handle);
+
+    _Requires_lock_not_held_(this->lock) void test_remove_flow_context(
+    uint64_t flow_id,
+    uint16_t layer_id,
+    _In_ const GUID& layer_guid);
 
     _Ret_maybenull_ const FWPM_FILTER*
     get_fwpm_filter_with_context_under_lock(_In_ const GUID& layer_guid)
@@ -297,6 +305,17 @@ typedef class fwp_engine_t
             }
         }
         return nullptr;
+    }
+
+    _Ret_maybenull_
+    size_t get_callout_id_from_key_under_lock(_In_ const GUID* callout_key)
+    {
+        for (auto& [first, callout] : fwps_callouts) {
+            if (callout.calloutKey == *callout_key) {
+                return first;
+            }
+        }
+        return 0;
     }
 
     static std::unique_ptr<fwp_engine_t> _engine;


### PR DESCRIPTION
Added apis for testing deletion of flow_context in sock_ops.

To delete a flow_context, flow_id is needed which gets assigned in test_callout. Made changes to the test_callout api to return the assigned flow_id so that it can be passed to the newly added remove_flow_context apis