### PR TITLE
Export IoFileObjectType mock

### DIFF
--- a/inc/usersim/ob.h
+++ b/inc/usersim/ob.h
@@ -12,6 +12,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL) USERSIM_API LONG_PTR ObfDereferenceObject(_I
 typedef struct _OBJECT_TYPE* POBJECT_TYPE;
 
 USERSIM_API extern POBJECT_TYPE* ExEventObjectType;
+USERSIM_API extern POBJECT_TYPE* IoFileObjectType;
 
 typedef struct _OBJECT_HANDLE_INFORMATION
 {

--- a/src/Source.def
+++ b/src/Source.def
@@ -6,6 +6,7 @@
 LIBRARY
 EXPORTS
     ExEventObjectType
+    IoFileObjectType
 
     FwpmCalloutAdd0
     FwpmCalloutDeleteByKey0

--- a/src/ob.cpp
+++ b/src/ob.cpp
@@ -11,6 +11,9 @@ static std::map<PVOID, ULONG> _object_references;
 static POBJECT_TYPE _ExEventObjectType = nullptr;
 USERSIM_API __declspec(align(8)) POBJECT_TYPE* ExEventObjectType = &_ExEventObjectType;
 
+static POBJECT_TYPE _IoFileObjectType = nullptr;
+USERSIM_API __declspec(align(8)) POBJECT_TYPE* IoFileObjectType = &_IoFileObjectType;
+
 _IRQL_requires_max_(DISPATCH_LEVEL) USERSIM_API LONG_PTR
 ObfReferenceObject(_In_ PVOID object)
 {


### PR DESCRIPTION
Add a mock for IoFileObjectType following the existing ExEventObjectType pattern.

### Changes
- **inc/usersim/ob.h**: Declare `IoFileObjectType` export
- **src/ob.cpp**: Define static backing variable and aligned exported pointer
- **src/Source.def**: Add `IoFileObjectType` to DLL exports