### PR TITLE
Mark object type exports as DATA

### DIFF
--- a/src/Source.def
+++ b/src/Source.def
@@ -5,8 +5,8 @@
 
 LIBRARY
 EXPORTS
-    ExEventObjectType
-    IoFileObjectType
+    ExEventObjectType DATA
+    IoFileObjectType DATA
 
     FwpmCalloutAdd0
     FwpmCalloutDeleteByKey0


### PR DESCRIPTION
## Summary
Mark ExEventObjectType and IoFileObjectType as DATA exports in src/Source.def.

## Why
These are exported globals, but the .def file listed them as plain exports. When an ARM64 import library is generated from that file, both symbols are emitted as Type: code instead of Type: data.

That mismatches how ebpf-for-windows consumes the symbols and can trigger ARM64 link failures such as the LNK2048 / LNK1165 relocation errors seen in the usersim-backed NativeOnlyDebug build.

## Validation
Generating an ARM64 import library from the updated Source.def changes both symbols to Type: data.
