### PR TITLE
Fix ARM64 alignment for object type exports

### DIFF
--- a/src/Source.def
+++ b/src/Source.def
@@ -5,8 +5,8 @@
 
 LIBRARY
 EXPORTS
-    ExEventObjectType
-    IoFileObjectType
+    ExEventObjectType DATA
+    IoFileObjectType DATA
 
     FwpmCalloutAdd0
     FwpmCalloutDeleteByKey0


### PR DESCRIPTION
Mark ExEventObjectType and IoFileObjectType as DATA exports in Source.def. Without DATA, the import library generates function-style thunks that are only 4-byte aligned on ARM64, but the ARM64 LDR instruction for 8-byte loads requires 8-byte alignment, causing LNK2048 relocation errors.

Consumers that reference these symbols without __declspec(dllimport) (e.g. via WDK headers) need /ALTERNATENAME linker flags to resolve the direct references against the __imp_ import symbols.