### PR TITLE
Add WFP listen hook simulation for sock_addr listen testing

### DIFF
--- a/inc/usersim/fwp_test.h
+++ b/inc/usersim/fwp_test.h
@@ -52,6 +52,12 @@ usersim_fwp_sock_ops_v4(_In_ fwp_classify_parameters_t* parameters, _Out_opt_ ui
 USERSIM_API FWP_ACTION_TYPE
 usersim_fwp_sock_ops_v6(_In_ fwp_classify_parameters_t* parameters, _Out_opt_ uint64_t* flow_id);
 
+USERSIM_API FWP_ACTION_TYPE
+usersim_fwp_sock_ops_listen_v4(_In_ fwp_classify_parameters_t* parameters);
+
+USERSIM_API FWP_ACTION_TYPE
+usersim_fwp_sock_ops_listen_v6(_In_ fwp_classify_parameters_t* parameters);
+
 USERSIM_API void
 usersim_fwp_set_sublayer_guids(
     _In_ const GUID& default_sublayer, _In_ const GUID& connect_v4_sublayer, _In_ const GUID& connect_v6_sublayer);

--- a/inc/usersim/fwp_test.h
+++ b/inc/usersim/fwp_test.h
@@ -53,10 +53,10 @@ USERSIM_API FWP_ACTION_TYPE
 usersim_fwp_sock_ops_v6(_In_ fwp_classify_parameters_t* parameters, _Out_opt_ uint64_t* flow_id);
 
 USERSIM_API FWP_ACTION_TYPE
-usersim_fwp_sock_ops_listen_v4(_In_ fwp_classify_parameters_t* parameters);
+usersim_fwp_cgroup_inet4_listen(_In_ fwp_classify_parameters_t* parameters);
 
 USERSIM_API FWP_ACTION_TYPE
-usersim_fwp_sock_ops_listen_v6(_In_ fwp_classify_parameters_t* parameters);
+usersim_fwp_cgroup_inet6_listen(_In_ fwp_classify_parameters_t* parameters);
 
 USERSIM_API void
 usersim_fwp_set_sublayer_guids(

--- a/src/fwp_um.cpp
+++ b/src/fwp_um.cpp
@@ -469,9 +469,9 @@ fwp_engine_t::test_sock_ops_v6(_In_ fwp_classify_parameters_t* parameters, _Out_
         FWPS_LAYER_ALE_FLOW_ESTABLISHED_V6, FWPM_LAYER_ALE_FLOW_ESTABLISHED_V6, _default_sublayer, incoming_value, flow_id);
 }
 
-// This is used to test the SOCK_OPS listen hook for IPv4 traffic.
+// This is used to test the sock_addr listen hook for IPv4 traffic.
 FWP_ACTION_TYPE
-fwp_engine_t::test_sock_ops_listen_v4(_In_ fwp_classify_parameters_t* parameters)
+fwp_engine_t::test_cgroup_inet4_listen(_In_ fwp_classify_parameters_t* parameters)
 {
     FWPS_INCOMING_VALUE0 incoming_value[FWPS_FIELD_ALE_AUTH_LISTEN_V4_MAX] = {};
     incoming_value[FWPS_FIELD_ALE_AUTH_LISTEN_V4_IP_LOCAL_ADDRESS].value.uint32 = parameters->destination_ipv4_address;
@@ -484,9 +484,9 @@ fwp_engine_t::test_sock_ops_listen_v4(_In_ fwp_classify_parameters_t* parameters
         FWPS_LAYER_ALE_AUTH_LISTEN_V4, FWPM_LAYER_ALE_AUTH_LISTEN_V4, _default_sublayer, incoming_value, nullptr);
 }
 
-// This is used to test the SOCK_OPS listen hook for IPv6 traffic.
+// This is used to test the sock_addr listen hook for IPv6 traffic.
 FWP_ACTION_TYPE
-fwp_engine_t::test_sock_ops_listen_v6(_In_ fwp_classify_parameters_t* parameters)
+fwp_engine_t::test_cgroup_inet6_listen(_In_ fwp_classify_parameters_t* parameters)
 {
     FWPS_INCOMING_VALUE0 incoming_value[FWPS_FIELD_ALE_AUTH_LISTEN_V6_MAX] = {};
     incoming_value[FWPS_FIELD_ALE_AUTH_LISTEN_V6_IP_LOCAL_ADDRESS].value.byteArray16 =
@@ -1075,15 +1075,15 @@ usersim_fwp_sock_ops_v6(_In_ fwp_classify_parameters_t* parameters, _Out_opt_ ui
 }
 
 FWP_ACTION_TYPE
-usersim_fwp_sock_ops_listen_v4(_In_ fwp_classify_parameters_t* parameters)
+usersim_fwp_cgroup_inet4_listen(_In_ fwp_classify_parameters_t* parameters)
 {
-    return fwp_engine_t::get()->test_sock_ops_listen_v4(parameters);
+    return fwp_engine_t::get()->test_cgroup_inet4_listen(parameters);
 }
 
 FWP_ACTION_TYPE
-usersim_fwp_sock_ops_listen_v6(_In_ fwp_classify_parameters_t* parameters)
+usersim_fwp_cgroup_inet6_listen(_In_ fwp_classify_parameters_t* parameters)
 {
-    return fwp_engine_t::get()->test_sock_ops_listen_v6(parameters);
+    return fwp_engine_t::get()->test_cgroup_inet6_listen(parameters);
 }
 
 void

--- a/src/fwp_um.cpp
+++ b/src/fwp_um.cpp
@@ -481,7 +481,7 @@ fwp_engine_t::test_sock_ops_listen_v4(_In_ fwp_classify_parameters_t* parameters
     incoming_value[FWPS_FIELD_ALE_AUTH_LISTEN_V4_ALE_APP_ID].value.byteBlob = &parameters->app_id;
 
     return test_callout(
-        FWPS_LAYER_ALE_AUTH_LISTEN_V4, FWPM_LAYER_ALE_AUTH_LISTEN_V4, _default_sublayer, incoming_value);
+        FWPS_LAYER_ALE_AUTH_LISTEN_V4, FWPM_LAYER_ALE_AUTH_LISTEN_V4, _default_sublayer, incoming_value, nullptr);
 }
 
 // This is used to test the SOCK_OPS listen hook for IPv6 traffic.
@@ -497,7 +497,7 @@ fwp_engine_t::test_sock_ops_listen_v6(_In_ fwp_classify_parameters_t* parameters
     incoming_value[FWPS_FIELD_ALE_AUTH_LISTEN_V6_ALE_APP_ID].value.byteBlob = &parameters->app_id;
 
     return test_callout(
-        FWPS_LAYER_ALE_AUTH_LISTEN_V6, FWPM_LAYER_ALE_AUTH_LISTEN_V6, _default_sublayer, incoming_value);
+        FWPS_LAYER_ALE_AUTH_LISTEN_V6, FWPM_LAYER_ALE_AUTH_LISTEN_V6, _default_sublayer, incoming_value, nullptr);
 }
 
 #pragma endregion fwp_engine_t

--- a/src/fwp_um.cpp
+++ b/src/fwp_um.cpp
@@ -469,6 +469,38 @@ fwp_engine_t::test_sock_ops_v6(_In_ fwp_classify_parameters_t* parameters, _Out_
         FWPS_LAYER_ALE_FLOW_ESTABLISHED_V6, FWPM_LAYER_ALE_FLOW_ESTABLISHED_V6, _default_sublayer, incoming_value, flow_id);
 }
 
+// This is used to test the SOCK_OPS listen hook for IPv4 traffic.
+FWP_ACTION_TYPE
+fwp_engine_t::test_sock_ops_listen_v4(_In_ fwp_classify_parameters_t* parameters)
+{
+    FWPS_INCOMING_VALUE0 incoming_value[FWPS_FIELD_ALE_AUTH_LISTEN_V4_MAX] = {};
+    incoming_value[FWPS_FIELD_ALE_AUTH_LISTEN_V4_IP_LOCAL_ADDRESS].value.uint32 = parameters->destination_ipv4_address;
+    incoming_value[FWPS_FIELD_ALE_AUTH_LISTEN_V4_IP_LOCAL_PORT].value.uint16 = parameters->destination_port;
+    incoming_value[FWPS_FIELD_ALE_AUTH_LISTEN_V4_COMPARTMENT_ID].value.uint32 = parameters->compartment_id;
+    incoming_value[FWPS_FIELD_ALE_AUTH_LISTEN_V4_IP_LOCAL_INTERFACE].value.uint64 = &parameters->interface_luid;
+    incoming_value[FWPS_FIELD_ALE_AUTH_LISTEN_V4_ALE_APP_ID].value.byteBlob = &parameters->app_id;
+
+    return test_callout(
+        FWPS_LAYER_ALE_AUTH_LISTEN_V4, FWPM_LAYER_ALE_AUTH_LISTEN_V4, _default_sublayer, incoming_value);
+}
+
+// This is used to test the SOCK_OPS listen hook for IPv6 traffic.
+FWP_ACTION_TYPE
+fwp_engine_t::test_sock_ops_listen_v6(_In_ fwp_classify_parameters_t* parameters)
+{
+    FWPS_INCOMING_VALUE0 incoming_value[FWPS_FIELD_ALE_AUTH_LISTEN_V6_MAX] = {};
+    incoming_value[FWPS_FIELD_ALE_AUTH_LISTEN_V6_IP_LOCAL_ADDRESS].value.byteArray16 =
+        &parameters->destination_ipv6_address;
+    incoming_value[FWPS_FIELD_ALE_AUTH_LISTEN_V6_IP_LOCAL_PORT].value.uint16 = parameters->destination_port;
+    incoming_value[FWPS_FIELD_ALE_AUTH_LISTEN_V6_COMPARTMENT_ID].value.uint32 = parameters->compartment_id;
+    incoming_value[FWPS_FIELD_ALE_AUTH_LISTEN_V6_IP_LOCAL_INTERFACE].value.uint64 = &parameters->interface_luid;
+    incoming_value[FWPS_FIELD_ALE_AUTH_LISTEN_V6_ALE_APP_ID].value.byteBlob = &parameters->app_id;
+
+    return test_callout(
+        FWPS_LAYER_ALE_AUTH_LISTEN_V6, FWPM_LAYER_ALE_AUTH_LISTEN_V6, _default_sublayer, incoming_value);
+}
+
+#pragma endregion fwp_engine_t
 
 #pragma region fwpm_apis
 
@@ -1040,6 +1072,18 @@ FWP_ACTION_TYPE
 usersim_fwp_sock_ops_v6(_In_ fwp_classify_parameters_t* parameters, _Out_opt_ uint64_t* flow_id)
 {
     return fwp_engine_t::get()->test_sock_ops_v6(parameters, flow_id);
+}
+
+FWP_ACTION_TYPE
+usersim_fwp_sock_ops_listen_v4(_In_ fwp_classify_parameters_t* parameters)
+{
+    return fwp_engine_t::get()->test_sock_ops_listen_v4(parameters);
+}
+
+FWP_ACTION_TYPE
+usersim_fwp_sock_ops_listen_v6(_In_ fwp_classify_parameters_t* parameters)
+{
+    return fwp_engine_t::get()->test_sock_ops_listen_v6(parameters);
 }
 
 void

--- a/src/fwp_um.h
+++ b/src/fwp_um.h
@@ -244,6 +244,12 @@ typedef class fwp_engine_t
     void 
     test_sock_ops_v6_remove_flow_context(_In_ uint64_t flow_id);
 
+    FWP_ACTION_TYPE
+    test_sock_ops_listen_v4(_In_ fwp_classify_parameters_t* parameters);
+
+    FWP_ACTION_TYPE
+    test_sock_ops_listen_v6(_In_ fwp_classify_parameters_t* parameters);
+
     static fwp_engine_t*
     get()
     {

--- a/src/fwp_um.h
+++ b/src/fwp_um.h
@@ -245,10 +245,10 @@ typedef class fwp_engine_t
     test_sock_ops_v6_remove_flow_context(_In_ uint64_t flow_id);
 
     FWP_ACTION_TYPE
-    test_sock_ops_listen_v4(_In_ fwp_classify_parameters_t* parameters);
+    test_cgroup_inet4_listen(_In_ fwp_classify_parameters_t* parameters);
 
     FWP_ACTION_TYPE
-    test_sock_ops_listen_v6(_In_ fwp_classify_parameters_t* parameters);
+    test_cgroup_inet6_listen(_In_ fwp_classify_parameters_t* parameters);
 
     static fwp_engine_t*
     get()


### PR DESCRIPTION
Add usersim_fwp_cgroup_inet4_listen and usersim_fwp_cgroup_inet6_listen to simulate WFP ALE_AUTH_LISTEN_V4/V6 layer classify calls. These enable unit testing of the
new cgroup/listen4 and cgroup/listen6 sock_addr attach types in ebpf-for-windows.

The functions populate FWPS_FIELD_ALE_AUTH_LISTEN_V4/V6 incoming values (local address, port, compartment ID, interface LUID, app ID) and invoke the registered WFP callout via test_callout.