### PR TITLE
Fix test_callout to dispatch via filter's bound calloutKey + add bind_ipv6 helper

### DIFF
--- a/inc/usersim/fwp_test.h
+++ b/inc/usersim/fwp_test.h
@@ -35,6 +35,9 @@ USERSIM_API FWP_ACTION_TYPE
 usersim_fwp_bind_ipv4(_In_ fwp_classify_parameters_t* parameters);
 
 USERSIM_API FWP_ACTION_TYPE
+usersim_fwp_bind_ipv6(_In_ fwp_classify_parameters_t* parameters);
+
+USERSIM_API FWP_ACTION_TYPE
 usersim_fwp_cgroup_inet4_recv_accept(_In_ fwp_classify_parameters_t* parameters);
 
 USERSIM_API FWP_ACTION_TYPE

--- a/src/fwp_um.cpp
+++ b/src/fwp_um.cpp
@@ -138,10 +138,37 @@ fwp_engine_t::test_bind_ipv4(_In_ fwp_classify_parameters_t* parameters)
         parameters->destination_ipv4_address;
     incoming_value[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_IP_PROTOCOL].value.uint8 = parameters->protocol;
     incoming_value[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_ALE_APP_ID].value.byteBlob = &parameters->app_id;
+    incoming_value[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_COMPARTMENT_ID].value.uint32 = parameters->compartment_id;
+    incoming_value[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_IP_LOCAL_INTERFACE].value.uint64 =
+        const_cast<UINT64*>(&parameters->interface_luid);
+    incoming_value[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_ALE_USER_ID].value.byteBlob = &parameters->user_id;
 
     return test_callout(
         FWPS_LAYER_ALE_RESOURCE_ASSIGNMENT_V4,
         FWPM_LAYER_ALE_RESOURCE_ASSIGNMENT_V4,
+        _default_sublayer,
+        incoming_value,
+        nullptr);
+}
+
+// This is used to test the IPv6 bind hook.
+FWP_ACTION_TYPE
+fwp_engine_t::test_bind_ipv6(_In_ fwp_classify_parameters_t* parameters)
+{
+    FWPS_INCOMING_VALUE0 incoming_value[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V6_MAX] = {};
+    incoming_value[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V6_IP_LOCAL_PORT].value.uint16 = parameters->destination_port;
+    incoming_value[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V6_IP_LOCAL_ADDRESS].value.byteArray16 =
+        &parameters->destination_ipv6_address;
+    incoming_value[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V6_IP_PROTOCOL].value.uint8 = parameters->protocol;
+    incoming_value[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V6_ALE_APP_ID].value.byteBlob = &parameters->app_id;
+    incoming_value[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V6_COMPARTMENT_ID].value.uint32 = parameters->compartment_id;
+    incoming_value[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V6_IP_LOCAL_INTERFACE].value.uint64 =
+        const_cast<UINT64*>(&parameters->interface_luid);
+    incoming_value[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V6_ALE_USER_ID].value.byteBlob = &parameters->user_id;
+
+    return test_callout(
+        FWPS_LAYER_ALE_RESOURCE_ASSIGNMENT_V6,
+        FWPM_LAYER_ALE_RESOURCE_ASSIGNMENT_V6,
         _default_sublayer,
         incoming_value,
         nullptr);
@@ -167,12 +194,10 @@ _Requires_lock_not_held_(this->lock) FWP_ACTION_TYPE fwp_engine_t::test_callout(
         }
         fwps_filter.context = fwpm_filter->rawContext;
 
-        const GUID* callout_key = get_callout_key_from_layer_guid_under_lock(&layer_guid);
-        if (callout_key == nullptr) {
-            return FWP_ACTION_CALLOUT_UNKNOWN;
-        }
-
-        callout = get_callout_from_key_under_lock(callout_key);
+        // Look up the callout via the filter's calloutKey rather than scanning by layer.
+        // This matches real WFP behavior where each filter is bound to a specific callout
+        // and correctly handles multiple callouts registered at the same WFP layer.
+        callout = get_callout_from_key_under_lock(&fwpm_filter->action.calloutKey);
         if (callout == nullptr) {
             return FWP_ACTION_CALLOUT_UNKNOWN;
         }
@@ -1004,6 +1029,12 @@ FWP_ACTION_TYPE
 usersim_fwp_bind_ipv4(_In_ fwp_classify_parameters_t* parameters)
 {
     return fwp_engine_t::get()->test_bind_ipv4(parameters);
+}
+
+FWP_ACTION_TYPE
+usersim_fwp_bind_ipv6(_In_ fwp_classify_parameters_t* parameters)
+{
+    return fwp_engine_t::get()->test_bind_ipv6(parameters);
 }
 
 FWP_ACTION_TYPE

--- a/src/fwp_um.h
+++ b/src/fwp_um.h
@@ -221,6 +221,9 @@ typedef class fwp_engine_t
     test_bind_ipv4(_In_ fwp_classify_parameters_t* parameters);
 
     FWP_ACTION_TYPE
+    test_bind_ipv6(_In_ fwp_classify_parameters_t* parameters);
+
+    FWP_ACTION_TYPE
     test_cgroup_inet4_recv_accept(_In_ fwp_classify_parameters_t* parameters);
 
     FWP_ACTION_TYPE


### PR DESCRIPTION
# Description

Add support for multiple callouts per layer, add IPv6 bind callout, and populate additional bind callout fields.

## Problem

fwp_engine_t::test_callout() looks up the callout by layer alone via get_callout_key_from_layer_guid_under_lock(), which returns the first fwpm_callouts entry matching the layer.
 
  - Real WFP dispatches each filter to the specific callout it's bound to via action.calloutKey. usersim already records that binding during add_fwpm_filter (see src/fwp_um.h:140) — test_callout just discards it.
  - The behavior is non-deterministic when more than one callout is registered at the same WFP layer, which is a normal pattern in real WFP and blocks tests for any project that does it.
 
 ## Fix

Look up the callout via the filter's bound action.calloutKey instead of scanning by layer:
 
```
  -        const GUID* callout_key = get_callout_key_from_layer_guid_under_lock(&layer_guid);
  -        if (callout_key == nullptr) {
  -            return FWP_ACTION_CALLOUT_UNKNOWN;
  -        }
  -        callout = get_callout_from_key_under_lock(callout_key);
  +        callout = get_callout_from_key_under_lock(&fwpm_filter->action.calloutKey);
``` 

 For tests with one callout per layer (today's status quo) the behavior is identical. For tests with multiple callouts per layer it now matches real WFP.
 
## Additional changes (related, small).
 
  - Add usersim_fwp_bind_ipv6() mirroring the existing usersim_fwp_bind_ipv4().
  - In test_bind_ipv4 / test_bind_ipv6, populate COMPARTMENT_ID, IP_LOCAL_INTERFACE, and ALE_USER_ID incoming values. These are read by sock_addr-style bind callbacks but ignored by the legacy bind callback, so the addition is non-breaking.
 
 Motivation. This surfaced while adding a BPF_PROG_TYPE_CGROUP_SOCK_ADDR bind hook (BPF_CGROUP_INET4/6_BIND) to eBPF for Windows, which coexists with the existing legacy bind hook at FWPM_LAYER_ALE_RESOURCE_ASSIGNMENT_V4/V6. Without this fix, unit tests can't reliably target one callout vs. the other when both are registered.