### PR TITLE
Move NT process-telemetry declarations into a public header

### DIFF
--- a/inc/usersim/nt_process_info.h
+++ b/inc/usersim/nt_process_info.h
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+// Native NT process-telemetry query definitions used to implement (usersim's PsGetProcessStartKey)
+// and to verify (eBPF for Windows api_test) the process start key. Per the official documentation
+// these types "have no associated import library or header file", so they must be declared locally;
+// this shared header keeps usersim and its consumers from maintaining divergent private copies.
+//
+// This is a leaf header: it only declares native NT types and depends solely on the basic Windows
+// integer/handle/status types (ULONG, ULONG64, HANDLE, PVOID, PULONG, NTSTATUS, NTAPI). Include it
+// after <windows.h> (and, where NTSTATUS is not otherwise available, a header that provides it).
+//
+// https://learn.microsoft.com/en-us/windows/win32/devnotes/process_telemetry_id_information_type
+
+typedef struct _PROCESS_TELEMETRY_ID_INFORMATION
+{
+    ULONG HeaderSize;
+    ULONG ProcessId;
+    ULONG64 ProcessStartKey;
+    ULONG64 CreateTime;
+    ULONG64 CreateInterruptTime;
+    ULONG64 CreateUnbiasedInterruptTime;
+    ULONG64 ProcessSequenceNumber;
+    ULONG64 SessionCreateTime;
+    ULONG SessionId;
+    ULONG BootId;
+    ULONG ImageChecksum;
+    ULONG ImageTimeDateStamp;
+    ULONG UserSidOffset;
+    ULONG ImagePathOffset;
+    ULONG PackageNameOffset;
+    ULONG RelativeAppNameOffset;
+    ULONG CommandLineOffset;
+} PROCESS_TELEMETRY_ID_INFORMATION, *PPROCESS_TELEMETRY_ID_INFORMATION;
+
+// ProcessInformationClass value used to query PROCESS_TELEMETRY_ID_INFORMATION.
+enum
+{
+    ProcessTelemetryIdInformation = 64
+};
+
+typedef NTSTATUS(NTAPI* NtQueryInformationProcess_t)(
+    _In_ HANDLE ProcessHandle,
+    _In_ ULONG ProcessInformationClass,
+    _Out_writes_bytes_(ProcessInformationLength) PVOID ProcessInformation,
+    _In_ ULONG ProcessInformationLength,
+    _Out_opt_ PULONG ReturnLength);

--- a/src/ps.cpp
+++ b/src/ps.cpp
@@ -3,6 +3,7 @@
 
 #include "kernel_um.h"
 #include "platform.h"
+#include "usersim/nt_process_info.h"
 #include "usersim/ps.h"
 
 #include <assert.h>
@@ -18,45 +19,6 @@ _IRQL_requires_max_(DISPATCH_LEVEL) NTKERNELAPI HANDLE PsGetCurrentThreadId()
 {
     return (HANDLE)(uintptr_t)GetCurrentThreadId();
 }
-
-typedef struct _PROCESS_TELEMETRY_ID_INFORMATION
-{
-    ULONG HeaderSize;
-    ULONG ProcessId;
-    ULONG64 ProcessStartKey;
-    ULONG64 CreateTime;
-    ULONG64 CreateInterruptTime;
-    ULONG64 CreateUnbiasedInterruptTime;
-    ULONG64 ProcessSequenceNumber;
-    ULONG64 SessionCreateTime;
-    ULONG SessionId;
-    ULONG BootId;
-    ULONG ImageChecksum;
-    ULONG ImageTimeDateStamp;
-    ULONG UserSidOffset;
-    ULONG ImagePathOffset;
-    ULONG PackageNameOffset;
-    ULONG RelativeAppNameOffset;
-    ULONG CommandLineOffset;
-} PROCESS_TELEMETRY_ID_INFORMATION, *PPROCESS_TELEMETRY_ID_INFORMATION;
-
-typedef enum _PROCESSINFOCLASS
-{
-    ProcessBasicInformation = 0,
-    ProcessDebugPort = 7,
-    ProcessWow64Information = 26,
-    ProcessImageFileName = 27,
-    ProcessBreakOnTermination = 29,
-    ProcessTelemetryIdInformation = 64,
-    ProcessSubsystemInformation = 75
-} PROCESSINFOCLASS;
-
-typedef NTSTATUS (NTAPI *NtQueryInformationProcess_t)(
-    _In_ HANDLE ProcessHandle,
-    _In_ PROCESSINFOCLASS ProcessInformationClass,
-    _Out_writes_bytes_(ProcessInformationLength) PVOID ProcessInformation,
-    _In_ ULONG ProcessInformationLength,
-    _Out_opt_ PULONG ReturnLength);
 
 static PGETPROCESSSTARTKEY _usersim_get_process_start_key_callback = nullptr;
 USERSIM_API

--- a/src/usersim.vcxproj
+++ b/src/usersim.vcxproj
@@ -131,6 +131,7 @@
     <ClInclude Include="ndis.h" />
     <ClInclude Include="net_platform.h" />
     <ClInclude Include="nmr_impl.h" />
+    <ClInclude Include="..\inc\usersim\nt_process_info.h" />
     <ClInclude Include="..\inc\usersim\ps.h" />
     <ClInclude Include="..\inc\usersim\rtl.h" />
     <ClInclude Include="..\inc\usersim\se.h" />


### PR DESCRIPTION
## Summary

`PsGetProcessStartKey` is implemented on top of the native NT
`PROCESS_TELEMETRY_ID_INFORMATION` structure and the `NtQueryInformationProcess`
API. Per Microsoft's documentation these have no public SDK header and must be
declared by hand, and today usersim declares them privately inside `src/ps.cpp`.
Because the declarations live in a `.cpp`, anything else that needs the same
native definitions cannot reuse them and has to maintain a separate,
drift-prone copy.

Promote those declarations to a public leaf header,
`inc/usersim/nt_process_info.h`, so they are defined once and can be reused by
usersim consumers.

## Changes

- Add `inc/usersim/nt_process_info.h` declaring `PROCESS_TELEMETRY_ID_INFORMATION`,
  the `ProcessTelemetryIdInformation` information-class value, and the
  `NtQueryInformationProcess_t` function-pointer typedef.
- `src/ps.cpp` includes the new header and drops its local declarations; the
  `PsGetProcessStartKey` logic is unchanged.
- Register the header in `src/usersim.vcxproj`.

## Design notes

The header is intentionally a leaf: it declares only native NT types and depends
solely on basic Windows types (`ULONG`/`HANDLE`/`NTSTATUS`/`NTAPI`/...), with no
usersim platform dependencies, so it can be included on its own without pulling
in usersim's internal headers. `NtQueryInformationProcess_t` uses `ULONG` for the
information-class parameter so the header does not also need to carry a
`PROCESSINFOCLASS` enum.

## Testing

- usersim builds clean (Debug/x64); no functional change.
- The new header is self-contained and compiles when included standalone.

## Context

Prompted by review of the corresponding eBPF for Windows change
(microsoft/ebpf-for-windows#5383).