### PR TITLE
fix mock NMR deregister race.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION }}
       shell: cmd
       run: |
-        powershell ..\..\scripts\Test-FaultInjection.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ".\usersim_tests.exe" 4
+        powershell ..\..\scripts\Test-FaultInjection.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ".\usersim_tests.exe" 4 "~[no_fi]"
 
   build-cmake:
     timeout-minutes: 15
@@ -151,4 +151,4 @@ jobs:
       working-directory: ./build/bin/${{env.BUILD_CONFIGURATION}}
       shell: cmd
       run: |
-        powershell ..\..\..\scripts\Test-FaultInjection.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ".\usersim_tests.exe" 4
+        powershell ..\..\..\scripts\Test-FaultInjection.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ".\usersim_tests.exe" 4 "~[no_fi]"

--- a/scripts/Test-FaultInjection.ps1
+++ b/scripts/Test-FaultInjection.ps1
@@ -12,7 +12,7 @@
 param ($OutputFolder, $Timeout, $TestProgram, $StackDepth)
 
 # Gather list of all possible tests
-$tests = & $TestProgram "--list-tests" "--verbosity=quiet"
+$tests = & $TestProgram "--list-tests" "--verbosity=quiet" "~[no_fi]"
 
 $env:CXPLAT_FAULT_INJECTION_SIMULATION = $StackDepth
 

--- a/src/nmr_impl.cpp
+++ b/src/nmr_impl.cpp
@@ -189,9 +189,15 @@ nmr_t::bind(_Inout_ client_registration& client, _Inout_ provider_registration& 
         if (!NT_SUCCESS(status)) {
             unbind_complete(*binding_ptr);
         } else {
+            bool should_begin_unbind = false;
             std::unique_lock l(lock);
             binding_ptr->client_binding_status = binding_status::Ready;
             binding_ptr->provider_binding_status = binding_status::Ready;
+            should_begin_unbind = binding_ptr->client.deregistering || binding_ptr->provider.deregistering;
+            l.unlock();
+            if (should_begin_unbind) {
+                (void)begin_unbind(*binding_ptr);
+            }
         }
     }};
 }
@@ -221,12 +227,13 @@ nmr_t::unbind_complete(_Inout_ binding& binding)
     bindings_changed.notify_all();
 }
 
-bool // true if pending, false if complete.
+bool
 nmr_t::begin_unbind(_Inout_ binding& binding)
 {
     std::unique_lock l(lock);
     if (binding.client_binding_status != Ready || binding.provider_binding_status != Ready) {
-        // Unbind already started.
+        // A Start binding is already published and contributes to binding_count, so deregistration
+        // must keep waiting even though detach cannot begin until attach finishes and reaches Ready.
         return true;
     }
     binding.client_binding_status = BeginUnbind;
@@ -356,7 +363,7 @@ nmr_t::perform_bind(
 }
 
 template <typename initiator_collection_t>
-bool // true if pending, false if complete
+bool
 nmr_t::perform_unbind(
     _Inout_ initiator_collection_t& initiator_collection,
     _In_ initiator_collection_t::value_type::first_type initiator_handle)

--- a/src/nmr_impl.cpp
+++ b/src/nmr_impl.cpp
@@ -15,20 +15,14 @@ nmr_t::register_provider(_In_ const NPI_PROVIDER_CHARACTERISTICS& characteristic
     return provider_handle;
 }
 
-bool
+void
 nmr_t::deregister_provider(_In_ nmr_provider_handle provider_handle)
 {
     // Block new bindings.
     deactivate(providers, provider_handle);
 
-    // If the unbind returned pending, then the caller needs to wait for the unbind to complete.
-    if (perform_unbind(providers, provider_handle)) {
-        // Pending unbind.
-        return true;
-    }
-    // Unbind is complete.
-    remove(providers, provider_handle);
-    return false;
+    // The caller always waits for deregistration to complete.
+    perform_unbind(providers, provider_handle);
 }
 
 void
@@ -48,21 +42,14 @@ nmr_t::register_client(_In_ const NPI_CLIENT_CHARACTERISTICS& characteristics, _
     return client_handle;
 }
 
-bool
+void
 nmr_t::deregister_client(_In_ nmr_client_handle client_handle)
 {
     // Block new bindings.
     deactivate(clients, client_handle);
 
-    // If the unbind returned pending, then the caller needs to wait for the unbind to complete.
-    if (perform_unbind(clients, client_handle)) {
-        // Pending unbind.
-        return true;
-    }
-
-    // Unbind is complete.
-    remove(clients, client_handle);
-    return false;
+    // The caller always waits for deregistration to complete.
+    perform_unbind(clients, client_handle);
 }
 
 void
@@ -81,7 +68,8 @@ nmr_t::binding_detach_client_complete(_In_ nmr_binding_handle binding_handle)
         throw std::runtime_error("invalid handle");
     }
 
-    nmr_t::binding& binding = *it->second;
+    auto binding_reference = it->second;
+    nmr_t::binding& binding = *binding_reference;
 
     ASSERT(binding.client_binding_status == binding_status::UnbindPending);
     binding.client_binding_status = UnbindComplete;
@@ -102,7 +90,8 @@ nmr_t::binding_detach_provider_complete(_In_ nmr_binding_handle binding_handle)
         throw std::runtime_error("invalid handle");
     }
 
-    nmr_t::binding& binding = *it->second;
+    auto binding_reference = it->second;
+    nmr_t::binding& binding = *binding_reference;
 
     ASSERT(binding.provider_binding_status == binding_status::UnbindPending);
     binding.provider_binding_status = UnbindComplete;
@@ -155,7 +144,7 @@ nmr_t::client_attach_provider(
 
 // Assumes caller does NOT have the lock held since we call outside NMR.
 std::optional<nmr_t::pending_action_t>
-nmr_t::bind(_Inout_ client_registration& client, _Inout_ provider_registration& provider)
+nmr_t::bind(_Inout_ client_module& client, _Inout_ provider_module& provider)
 {
     PNPIID client_pnpi = client.characteristics.ClientRegistrationInstance.NpiId;
     PNPIID provider_pnpi = provider.characteristics.ProviderRegistrationInstance.NpiId;
@@ -170,9 +159,9 @@ nmr_t::bind(_Inout_ client_registration& client, _Inout_ provider_registration& 
         return std::nullopt;
     }
 
-    // Acquire references on both client and provider to prevent them from unloading.
-    _InterlockedIncrement64(&client.binding_count);
-    _InterlockedIncrement64(&provider.binding_count);
+    // Hold both modules while the attach action is pending.
+    client.pending_bind_ops++;
+    provider.pending_bind_ops++;
 
     nmr_t::binding binding = {provider, client};
     auto binding_ptr = std::make_shared<nmr_t::binding>(std::move(binding));
@@ -193,10 +182,19 @@ nmr_t::bind(_Inout_ client_registration& client, _Inout_ provider_registration& 
             std::unique_lock l(lock);
             binding_ptr->client_binding_status = binding_status::Ready;
             binding_ptr->provider_binding_status = binding_status::Ready;
+            binding_ptr->attached = true;
+            client.pending_bind_ops--;
+            provider.pending_bind_ops--;
+            client.bindings.push_back(binding_ptr);
+            provider.bindings.push_back(binding_ptr);
             should_begin_unbind = binding_ptr->client.deregistering || binding_ptr->provider.deregistering;
+            if (should_begin_unbind) {
+                binding_ptr->client_binding_status = binding_status::LateBind;
+                binding_ptr->provider_binding_status = binding_status::LateBind;
+            }
             l.unlock();
             if (should_begin_unbind) {
-                (void)begin_unbind(*binding_ptr);
+                begin_unbind(*binding_ptr);
             }
         }
     }};
@@ -206,6 +204,11 @@ void
 nmr_t::unbind_complete(_Inout_ binding& binding)
 {
     std::unique_lock l(lock);
+    if (binding.cleanup_started) {
+        return;
+    }
+    binding.cleanup_started = true;
+
     if ((binding.client.characteristics.ClientCleanupBindingContext != nullptr) &&
         (binding.client_binding_context != nullptr)) {
         // Notify the client that that the binding context can be freed if needed.
@@ -219,22 +222,40 @@ nmr_t::unbind_complete(_Inout_ binding& binding)
             const_cast<void*>(binding.provider_binding_context));
     }
 
-    _InterlockedDecrement64(&binding.provider.binding_count);
-    _InterlockedDecrement64(&binding.client.binding_count);
+    if (binding.attached) {
+        auto remove_binding = [&binding](auto& module) {
+            auto it = std::find_if(module.bindings.begin(), module.bindings.end(), [&binding](const auto& entry) {
+                return entry.get() == &binding;
+            });
+            if (it != module.bindings.end()) {
+                module.bindings.erase(it);
+            }
+        };
+        remove_binding(binding.provider);
+        remove_binding(binding.client);
+    } else {
+        CXPLAT_DEBUG_ASSERT(binding.client.pending_bind_ops > 0);
+        CXPLAT_DEBUG_ASSERT(binding.provider.pending_bind_ops > 0);
+        binding.client.pending_bind_ops--;
+        binding.provider.pending_bind_ops--;
+    }
+
     bindings.erase(&binding);
 
     // Notify the client or provider to check if they have any pending bindings.
     bindings_changed.notify_all();
 }
 
-bool
+void
 nmr_t::begin_unbind(_Inout_ binding& binding)
 {
     std::unique_lock l(lock);
-    if (binding.client_binding_status != Ready || binding.provider_binding_status != Ready) {
-        // A Start binding is already published and contributes to binding_count, so deregistration
-        // must keep waiting even though detach cannot begin until attach finishes and reaches Ready.
-        return true;
+    const bool client_ready = binding.client_binding_status == Ready || binding.client_binding_status == LateBind;
+    const bool provider_ready = binding.provider_binding_status == Ready || binding.provider_binding_status == LateBind;
+    if (!client_ready || !provider_ready) {
+        // A non-ready binding is either still being attached or already being unbound.
+        // In either case, another caller must not start a second unbind operation.
+        return;
     }
     binding.client_binding_status = BeginUnbind;
     binding.provider_binding_status = BeginUnbind;
@@ -269,9 +290,7 @@ nmr_t::begin_unbind(_Inout_ binding& binding)
 
     if (complete) {
         unbind_complete(binding);
-        return false;
     }
-    return true;
 }
 
 template <typename collection_t, typename characteristics_t>
@@ -308,17 +327,18 @@ nmr_t::remove(_Inout_ collection_t& collection, _In_ collection_t::value_type::f
         throw std::runtime_error("invalid handle");
     }
 
-    // Wait for bindings to reach zero if requested.
-    if (it->second.binding_count > 0) {
+    // Wait until there are no attached bindings and no bind operations still pending
+    // before cleaning up the client or provider module.
+    if (it->second.pending_bind_ops > 0 || !it->second.bindings.empty()) {
         for (;;) {
-            // Wait NMR_WAIT_TIMEOUT_SECONDS seconds for bindings to reach zero.
+            // Wait NMR_WAIT_TIMEOUT_SECONDS seconds for all bindings to be released.
             if (bindings_changed.wait_for(l, std::chrono::seconds(NMR_WAIT_TIMEOUT_SECONDS), [&]() {
-                    return it->second.binding_count == 0;
+                    return it->second.pending_bind_ops == 0 && it->second.bindings.empty();
                 })) {
                 break;
             }
             // Assert and continue waiting if bindings are still not zero.
-            CXPLAT_DEBUG_ASSERT(it->second.binding_count == 0);
+            CXPLAT_DEBUG_ASSERT(it->second.pending_bind_ops == 0 && it->second.bindings.empty());
         }
     }
 
@@ -342,14 +362,14 @@ nmr_t::perform_bind(
     auto& initiator = it->second;
     for (auto& [target_handle, target] : target_collection) {
         // If the initiator is a client, then the target must be a provider.
-        if constexpr (std::is_same<initiator_collection_t::value_type::second_type, client_registration>::value) {
+        if constexpr (std::is_same<initiator_collection_t::value_type::second_type, client_module>::value) {
             auto result = bind(initiator, target);
             if (result.has_value()) {
                 pending_actions.push_back(result.value());
             }
         }
         // If the initiator is a provider, then the target must be a client.
-        if constexpr (std::is_same<initiator_collection_t::value_type::second_type, provider_registration>::value) {
+        if constexpr (std::is_same<initiator_collection_t::value_type::second_type, provider_module>::value) {
             auto result = bind(target, initiator);
             if (result.has_value()) {
                 pending_actions.push_back(result.value());
@@ -363,12 +383,11 @@ nmr_t::perform_bind(
 }
 
 template <typename initiator_collection_t>
-bool
+void
 nmr_t::perform_unbind(
     _Inout_ initiator_collection_t& initiator_collection,
     _In_ initiator_collection_t::value_type::first_type initiator_handle)
 {
-    bool pending = false;
     std::vector<std::shared_ptr<binding>> bindings_to_unbind;
     std::unique_lock l(lock);
     auto it = initiator_collection.find(initiator_handle);
@@ -381,13 +400,13 @@ nmr_t::perform_unbind(
         auto& binding = *binding_reference;
 
         // If the initiator is a client, then the target must be a provider.
-        if constexpr (std::is_same<initiator_collection_t::value_type::second_type, client_registration>::value) {
+        if constexpr (std::is_same<initiator_collection_t::value_type::second_type, client_module>::value) {
             if (&binding.client == &initiator) {
                 bindings_to_unbind.push_back(binding_reference);
             }
         }
         // If the initiator is a provider, then the target must be a client.
-        if constexpr (std::is_same<initiator_collection_t::value_type::second_type, provider_registration>::value) {
+        if constexpr (std::is_same<initiator_collection_t::value_type::second_type, provider_module>::value) {
             if (&binding.provider == &initiator) {
                 bindings_to_unbind.push_back(binding_reference);
             }
@@ -396,7 +415,6 @@ nmr_t::perform_unbind(
     l.unlock();
     for (auto& binding_reference : bindings_to_unbind) {
         auto& binding = *binding_reference;
-        pending |= begin_unbind(binding);
+        begin_unbind(binding);
     }
-    return pending;
 }

--- a/src/nmr_impl.h
+++ b/src/nmr_impl.h
@@ -148,7 +148,6 @@ typedef class nmr_t
         UnbindComplete ///< Client or provider detach returned STATUS_SUCCESS or called NmrBindingDetachClientComplete
                        ///< or NmrBindingDetachProviderComplete.
     };
-
     struct binding
     {
         provider_registration& provider;
@@ -250,7 +249,7 @@ typedef class nmr_t
      * @brief Start the process of unbinding a client from a provider.
      *
      * @param[in] binding_handle Binding handle to unbind.
-     * @retval true Either the client or provider returned pending.
+     * @retval true Either unbind cannot start yet or it is pending/in progress.
      * @retval false Both the client and provider returned successfully.
      */
     bool

--- a/src/nmr_impl.h
+++ b/src/nmr_impl.h
@@ -5,6 +5,7 @@
 #include "platform.h"
 
 #include <../km/netioddk.h>
+#include <algorithm>
 #include <condition_variable>
 #include <functional>
 #include <map>
@@ -28,19 +29,17 @@ typedef class nmr_t
      *
      * @param[in] characteristics Characteristics of the provider.
      * @param[in] context Context passed to the provider.
-     * @return Handle to the provider registration.
+     * @return Handle to the provider module.
      */
     nmr_provider_handle
     register_provider(_In_ const NPI_PROVIDER_CHARACTERISTICS& characteristics, _In_opt_ const void* context);
 
     /**
-     * @brief Deregister a provider.
+     * @brief Deregister a provider. The caller must wait for completion.
      *
      * @param[in] provider_handle Handle to the provider.
-     * @retval true Caller needs to wait for the deregistration to complete.
-     * @retval false Deregistration is complete.
      */
-    bool
+    void
     deregister_provider(_In_ nmr_provider_handle provider_handle);
 
     /**
@@ -56,19 +55,17 @@ typedef class nmr_t
      *
      * @param[in] characteristics Characteristics of the client.
      * @param[in] context Context passed to the client.
-     * @return Handle to the client registration.
+     * @return Handle to the client module.
      */
     nmr_client_handle
     register_client(_In_ const NPI_CLIENT_CHARACTERISTICS& characteristics, _In_opt_ const void* context);
 
     /**
-     * @brief Deregister a client.
+     * @brief Deregister a client. The caller must wait for completion.
      *
      * @param[in] client_handle Handle to the client.
-     * @retval true Caller needs to wait for the deregistration to complete.
-     * @retval false Deregistration is complete.
      */
-    bool
+    void
     deregister_client(_In_ nmr_client_handle client_handle);
 
     /**
@@ -122,19 +119,23 @@ typedef class nmr_t
     }
 
   private:
-    struct client_registration
+    struct binding;
+
+    struct client_module
     {
         const NPI_CLIENT_CHARACTERISTICS characteristics = {};
         const void* context = nullptr;
-        volatile long long binding_count = 0;
+        size_t pending_bind_ops = 0;
+        std::vector<std::shared_ptr<binding>> bindings;
         bool deregistering = false;
     };
 
-    struct provider_registration
+    struct provider_module
     {
         const NPI_PROVIDER_CHARACTERISTICS characteristics = {};
         const void* context = nullptr;
-        volatile long long binding_count = 0;
+        size_t pending_bind_ops = 0;
+        std::vector<std::shared_ptr<binding>> bindings;
         bool deregistering = false;
     };
 
@@ -142,6 +143,7 @@ typedef class nmr_t
     {
         Start = 0,   ///< Initial state. Binding has been created but ClientAttachProvider has not been called.
         Ready,       ///< ClientAttachProvider has been called and returned STATUS_SUCCESS.
+        LateBind,    ///< Attach completed after one of the modules started deregistering.
         BeginUnbind, ///< Client or provider has called NmrDeregisterClient or NmrDeregisterProvider but detach has not
                      ///< yet been called.
         UnbindPending, ///< Client or provider detach returned STATUS_PENDING.
@@ -150,14 +152,16 @@ typedef class nmr_t
     };
     struct binding
     {
-        provider_registration& provider;
-        client_registration& client;
+        provider_module& provider;
+        client_module& client;
         const void* provider_binding_context = nullptr;
         const void* provider_dispatch = nullptr;
         binding_status provider_binding_status = Start;
         const void* client_binding_context = nullptr;
         const void* client_dispatch = nullptr;
         binding_status client_binding_status = Start;
+        bool attached = false;
+        bool cleanup_started = false;
     };
     typedef std::function<void()> pending_action_t;
 
@@ -218,11 +222,9 @@ typedef class nmr_t
      *
      * @param[in, out] initiator_collection Collection containing the initiator (can be either provider or client).
      * @param[in] handle Handle to the initiator (can be either provider or client).
-     * @retval true One or more bindings returned pending.
-     * @retval false All bindings where successfully removed.
      */
     template <typename initiator_collection_t>
-    bool
+    void
     perform_unbind(
         _Inout_ initiator_collection_t& initiator_collection,
         _In_ initiator_collection_t::value_type::first_type initiator_handle);
@@ -232,10 +234,10 @@ typedef class nmr_t
      *
      * @param[in, out] client Client to attempt to bind.
      * @param[in, out] provider Provider to attempt to bind to.
-     * @return Contains a function to perform the bind if successful.
+     * @return Contains a function to perform the bind if accepted.
      */
     std::optional<pending_action_t>
-    bind(_Inout_ client_registration& client, _Inout_ provider_registration& provider);
+    bind(_Inout_ client_module& client, _Inout_ provider_module& provider);
 
     /**
      * @brief Finish the process of unbinding a client from a provider.
@@ -249,26 +251,22 @@ typedef class nmr_t
      * @brief Start the process of unbinding a client from a provider.
      *
      * @param[in] binding_handle Binding handle to unbind.
-     * @retval true Either unbind cannot start yet or it is pending/in progress.
-     * @retval false Both the client and provider returned successfully.
      */
-    bool
+    void
     begin_unbind(_Inout_ binding& binding);
 
     // Binding handle is a pointer to the binding.
     std::map<nmr_binding_handle, std::shared_ptr<binding>> bindings;
-    // Provider and client handles are incremented for each new provider or client.
-    std::map<nmr_provider_handle, provider_registration> providers;
-    std::map<nmr_client_handle, client_registration> clients;
+    // Provider and client handles.
+    std::map<nmr_provider_handle, provider_module> providers;
+    std::map<nmr_client_handle, client_module> clients;
 
     size_t next_handle = 1;
 
     std::condition_variable bindings_changed;
-    std::mutex lock; // Protects all of the instance variables above,
-                     // as well as the client_binding_status and provider_binding_status
-                     // of each binding.  client.binding_count and provider.binding_count
-                     // on the other hand are not protected by this lock but instead use
-                     // interlocked operations.
+    std::mutex lock; // Protects all of the instance variables above, as well as
+                     // the client_binding_status and provider_binding_status of
+                     // each binding.
 
     static nmr_t singleton;
 } nmr_t;

--- a/src/nmr_um.cpp
+++ b/src/nmr_um.cpp
@@ -28,11 +28,8 @@ NTSTATUS
 NmrDeregisterProvider(_In_ HANDLE nmr_provider_handle)
 {
     try {
-        if (nmr_t::get().deregister_provider(nmr_provider_handle)) {
-            return STATUS_PENDING;
-        } else {
-            return STATUS_SUCCESS;
-        }
+        nmr_t::get().deregister_provider(nmr_provider_handle);
+        return STATUS_PENDING;
     } catch (std::bad_alloc) {
         return STATUS_NO_MEMORY;
     }
@@ -81,11 +78,8 @@ NTSTATUS
 NmrDeregisterClient(_In_ HANDLE nmr_client_handle)
 {
     try {
-        if (nmr_t::get().deregister_client(nmr_client_handle)) {
-            return STATUS_PENDING;
-        } else {
-            return STATUS_SUCCESS;
-        }
+        nmr_t::get().deregister_client(nmr_client_handle);
+        return STATUS_PENDING;
     } catch (std::bad_alloc) {
         return STATUS_NO_MEMORY;
     }

--- a/tests/nmr_test.cpp
+++ b/tests/nmr_test.cpp
@@ -9,6 +9,7 @@
 #include "../src/framework.h"
 #include <../km/netioddk.h>
 #include <atomic>
+#include <chrono>
 #include <iostream>
 #include <thread>
 
@@ -421,13 +422,18 @@ TEST_CASE("NmrRegisterProvider with async deregister", "[nmr]")
 
 TEST_CASE("concurrent register/deregister smoke", "[nmr][no_fi]")
 {
-    constexpr size_t iteration_count = 1000;
-    std::atomic<size_t> provider_iterations{0};
-    std::atomic<size_t> client_iterations{0};
+    constexpr auto run_duration = std::chrono::seconds(30);
+    const auto test_start = std::chrono::steady_clock::now();
+    std::atomic<size_t> ready_threads{0};
+    std::atomic<bool> start{false};
 
-    std::thread provider_thread([iteration_count, &provider_iterations]() {
-        for (size_t i = 0; i < iteration_count; i++) {
-            provider_iterations++;
+    std::thread provider_thread([&ready_threads, &start, run_duration]() {
+        ready_threads++;
+        while (!start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        const auto deadline = std::chrono::steady_clock::now() + run_duration;
+        while (std::chrono::steady_clock::now() < deadline) {
             HANDLE nmr_provider_handle = nullptr;
             NTSTATUS register_status =
                 NmrRegisterProvider(&_smoke_provider_characteristics, nullptr, &nmr_provider_handle);
@@ -442,9 +448,13 @@ TEST_CASE("concurrent register/deregister smoke", "[nmr][no_fi]")
         }
     });
 
-    std::thread client_thread([iteration_count, &client_iterations]() {
-        for (size_t i = 0; i < iteration_count; i++) {
-            client_iterations++;
+    std::thread client_thread([&ready_threads, &start, run_duration]() {
+        ready_threads++;
+        while (!start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        const auto deadline = std::chrono::steady_clock::now() + run_duration;
+        while (std::chrono::steady_clock::now() < deadline) {
             HANDLE nmr_client_handle = nullptr;
             NTSTATUS register_status = NmrRegisterClient(&_smoke_client_characteristics, nullptr, &nmr_client_handle);
             if (!NT_SUCCESS(register_status)) {
@@ -458,9 +468,15 @@ TEST_CASE("concurrent register/deregister smoke", "[nmr][no_fi]")
         }
     });
 
+    while (ready_threads.load(std::memory_order_acquire) != 2) {
+        std::this_thread::yield();
+    }
+    start.store(true, std::memory_order_release);
+
     provider_thread.join();
     client_thread.join();
 
-    std::cout << "provider_iterations=" << provider_iterations.load() << ", client_iterations="
-              << client_iterations.load() << std::endl;
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - test_start);
+    std::cout << "smoke test duration: " << elapsed.count() << " ms" << std::endl;
 }

--- a/tests/nmr_test.cpp
+++ b/tests/nmr_test.cpp
@@ -8,6 +8,9 @@
 #endif
 #include "../src/framework.h"
 #include <../km/netioddk.h>
+#include <atomic>
+#include <iostream>
+#include <thread>
 
 NPIID test_npiid = {0};
 
@@ -153,6 +156,98 @@ NPI_PROVIDER_CHARACTERISTICS _test_provider_characteristics = {
     .ProviderRegistrationInstance = _test_provider_registration_instance};
 
 #pragma endregion test_nmr_provider
+
+#pragma region smoke_nmr_client_provider
+
+// Use a distinct NPI ID so smoke registrations never match the test_npiid registrations above,
+// preventing cross-contamination when test_npiid registrations are left over from failed tests.
+NPIID smoke_npiid = {1};
+
+NPI_REGISTRATION_INSTANCE _smoke_client_registration_instance = {
+    .Size = sizeof(NPI_REGISTRATION_INSTANCE), .NpiId = &smoke_npiid};
+NPI_REGISTRATION_INSTANCE _smoke_provider_registration_instance = {
+    .Size = sizeof(NPI_REGISTRATION_INSTANCE), .NpiId = &smoke_npiid};
+
+static NTSTATUS
+_smoke_client_attach_provider(
+    _In_ HANDLE nmr_binding_handle,
+    _In_opt_ void* client_context,
+    _In_ NPI_REGISTRATION_INSTANCE* provider_registration_instance)
+{
+    UNREFERENCED_PARAMETER(client_context);
+    UNREFERENCED_PARAMETER(provider_registration_instance);
+
+    void* provider_binding_context = nullptr;
+    const void* provider_dispatch = nullptr;
+    return NmrClientAttachProvider(
+        nmr_binding_handle,
+        reinterpret_cast<void*>(nmr_binding_handle),
+        TEST_CLIENT_DISPATCH,
+        &provider_binding_context,
+        &provider_dispatch);
+}
+
+static NTSTATUS
+_smoke_client_detach_provider(_In_ void* client_binding_context)
+{
+    UNREFERENCED_PARAMETER(client_binding_context);
+    return STATUS_SUCCESS;
+}
+
+static void
+_smoke_client_cleanup_binding_context(_In_ void* client_binding_context)
+{
+    UNREFERENCED_PARAMETER(client_binding_context);
+}
+
+NPI_CLIENT_CHARACTERISTICS _smoke_client_characteristics = {
+    .Length = sizeof(NPI_CLIENT_CHARACTERISTICS),
+    .ClientAttachProvider = (PNPI_CLIENT_ATTACH_PROVIDER_FN)_smoke_client_attach_provider,
+    .ClientDetachProvider = _smoke_client_detach_provider,
+    .ClientCleanupBindingContext = _smoke_client_cleanup_binding_context,
+    .ClientRegistrationInstance = _smoke_client_registration_instance};
+
+static NTSTATUS
+_smoke_provider_attach_client(
+    _In_ HANDLE nmr_binding_handle,
+    _In_opt_ void* provider_context,
+    _In_ NPI_REGISTRATION_INSTANCE* client_registration_instance,
+    _In_ void* client_binding_context,
+    _In_ const void* client_dispatch,
+    _Outptr_ void** provider_binding_context,
+    _Outptr_ const void** provider_dispatch)
+{
+    UNREFERENCED_PARAMETER(nmr_binding_handle);
+    UNREFERENCED_PARAMETER(provider_context);
+    UNREFERENCED_PARAMETER(client_registration_instance);
+    UNREFERENCED_PARAMETER(client_dispatch);
+
+    *provider_binding_context = client_binding_context;
+    *provider_dispatch = TEST_PROVIDER_DISPATCH;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS
+_smoke_provider_detach_client(_In_ void* provider_binding_context)
+{
+    UNREFERENCED_PARAMETER(provider_binding_context);
+    return STATUS_SUCCESS;
+}
+
+static void
+_smoke_provider_cleanup_binding_context(_In_ void* provider_binding_context)
+{
+    UNREFERENCED_PARAMETER(provider_binding_context);
+}
+
+NPI_PROVIDER_CHARACTERISTICS _smoke_provider_characteristics = {
+    .Length = sizeof(NPI_PROVIDER_CHARACTERISTICS),
+    .ProviderAttachClient = (PNPI_PROVIDER_ATTACH_CLIENT_FN)_smoke_provider_attach_client,
+    .ProviderDetachClient = _smoke_provider_detach_client,
+    .ProviderCleanupBindingContext = _smoke_provider_cleanup_binding_context,
+    .ProviderRegistrationInstance = _smoke_provider_registration_instance};
+
+#pragma endregion smoke_nmr_client_provider
 
 TEST_CASE("NmrRegisterClient", "[nmr]")
 {
@@ -322,4 +417,50 @@ TEST_CASE("NmrRegisterProvider with async deregister", "[nmr]")
     REQUIRE(_test_provider_binding_context.nmr_binding_handle == nullptr);
 
     REQUIRE(NmrDeregisterClient(nmr_client_handle) == STATUS_SUCCESS);
+}
+
+TEST_CASE("concurrent register/deregister smoke", "[nmr][no_fi]")
+{
+    constexpr size_t iteration_count = 1000;
+    std::atomic<size_t> provider_iterations{0};
+    std::atomic<size_t> client_iterations{0};
+
+    std::thread provider_thread([iteration_count, &provider_iterations]() {
+        for (size_t i = 0; i < iteration_count; i++) {
+            provider_iterations++;
+            HANDLE nmr_provider_handle = nullptr;
+            NTSTATUS register_status =
+                NmrRegisterProvider(&_smoke_provider_characteristics, nullptr, &nmr_provider_handle);
+            if (!NT_SUCCESS(register_status)) {
+                continue;
+            }
+
+            NTSTATUS deregister_status = NmrDeregisterProvider(nmr_provider_handle);
+            if (deregister_status == STATUS_PENDING) {
+                (void)NmrWaitForProviderDeregisterComplete(nmr_provider_handle);
+            }
+        }
+    });
+
+    std::thread client_thread([iteration_count, &client_iterations]() {
+        for (size_t i = 0; i < iteration_count; i++) {
+            client_iterations++;
+            HANDLE nmr_client_handle = nullptr;
+            NTSTATUS register_status = NmrRegisterClient(&_smoke_client_characteristics, nullptr, &nmr_client_handle);
+            if (!NT_SUCCESS(register_status)) {
+                continue;
+            }
+
+            NTSTATUS deregister_status = NmrDeregisterClient(nmr_client_handle);
+            if (deregister_status == STATUS_PENDING) {
+                (void)NmrWaitForClientDeregisterComplete(nmr_client_handle);
+            }
+        }
+    });
+
+    provider_thread.join();
+    client_thread.join();
+
+    std::cout << "provider_iterations=" << provider_iterations.load() << ", client_iterations="
+              << client_iterations.load() << std::endl;
 }

--- a/tests/nmr_test.cpp
+++ b/tests/nmr_test.cpp
@@ -7,6 +7,7 @@
 #include <catch2/catch.hpp>
 #endif
 #include "../src/framework.h"
+
 #include <../km/netioddk.h>
 #include <atomic>
 #include <chrono>
@@ -253,13 +254,14 @@ NPI_PROVIDER_CHARACTERISTICS _smoke_provider_characteristics = {
 TEST_CASE("NmrRegisterClient", "[nmr]")
 {
     HANDLE nmr_client_handle;
-    
+
     REQUIRE(NmrRegisterClient(&_test_client_characteristics, nullptr, &nmr_client_handle) == STATUS_SUCCESS);
 
     // Verify there was no binding callback, since there are no providers.
     REQUIRE(_test_client_binding_context.allocated == false);
 
-    REQUIRE(NmrDeregisterClient(nmr_client_handle) == STATUS_SUCCESS);
+    REQUIRE(NmrDeregisterClient(nmr_client_handle) == STATUS_PENDING);
+    REQUIRE(NmrWaitForClientDeregisterComplete(nmr_client_handle) == STATUS_SUCCESS);
 }
 
 TEST_CASE("NmrRegisterProvider", "[nmr]")
@@ -271,7 +273,8 @@ TEST_CASE("NmrRegisterProvider", "[nmr]")
     // Verify there was no binding callback, since there are no clients.
     REQUIRE(_test_provider_binding_context.allocated == false);
 
-    REQUIRE(NmrDeregisterProvider(nmr_provider_handle) == STATUS_SUCCESS);
+    REQUIRE(NmrDeregisterProvider(nmr_provider_handle) == STATUS_PENDING);
+    REQUIRE(NmrWaitForProviderDeregisterComplete(nmr_provider_handle) == STATUS_SUCCESS);
 }
 
 TEST_CASE("attach during NmrRegisterProvider", "[nmr]")
@@ -296,7 +299,8 @@ TEST_CASE("attach during NmrRegisterProvider", "[nmr]")
     REQUIRE(_test_provider_binding_context.client_dispatch == TEST_CLIENT_DISPATCH);
 
     // Deregister the provider first.
-    REQUIRE(NmrDeregisterProvider(nmr_provider_handle) == STATUS_SUCCESS);
+    REQUIRE(NmrDeregisterProvider(nmr_provider_handle) == STATUS_PENDING);
+    REQUIRE(NmrWaitForProviderDeregisterComplete(nmr_provider_handle) == STATUS_SUCCESS);
 
     REQUIRE(_test_client_binding_context.allocated == false);
     REQUIRE(_test_client_binding_context.nmr_binding_handle == nullptr);
@@ -308,7 +312,8 @@ TEST_CASE("attach during NmrRegisterProvider", "[nmr]")
     REQUIRE(_test_provider_binding_context.client_binding_context == nullptr);
     REQUIRE(_test_provider_binding_context.client_dispatch == nullptr);
 
-    REQUIRE(NmrDeregisterClient(nmr_client_handle) == STATUS_SUCCESS);
+    REQUIRE(NmrDeregisterClient(nmr_client_handle) == STATUS_PENDING);
+    REQUIRE(NmrWaitForClientDeregisterComplete(nmr_client_handle) == STATUS_SUCCESS);
 }
 
 TEST_CASE("attach during NmrRegisterClient", "[nmr]")
@@ -333,7 +338,8 @@ TEST_CASE("attach during NmrRegisterClient", "[nmr]")
     REQUIRE(_test_provider_binding_context.client_dispatch == TEST_CLIENT_DISPATCH);
 
     // Deregister the client first.
-    REQUIRE(NmrDeregisterClient(nmr_client_handle) == STATUS_SUCCESS);
+    REQUIRE(NmrDeregisterClient(nmr_client_handle) == STATUS_PENDING);
+    REQUIRE(NmrWaitForClientDeregisterComplete(nmr_client_handle) == STATUS_SUCCESS);
 
     REQUIRE(_test_client_binding_context.allocated == false);
     REQUIRE(_test_client_binding_context.nmr_binding_handle == nullptr);
@@ -345,7 +351,8 @@ TEST_CASE("attach during NmrRegisterClient", "[nmr]")
     REQUIRE(_test_provider_binding_context.client_binding_context == nullptr);
     REQUIRE(_test_provider_binding_context.client_dispatch == nullptr);
 
-    REQUIRE(NmrDeregisterProvider(nmr_provider_handle) == STATUS_SUCCESS);
+    REQUIRE(NmrDeregisterProvider(nmr_provider_handle) == STATUS_PENDING);
+    REQUIRE(NmrWaitForProviderDeregisterComplete(nmr_provider_handle) == STATUS_SUCCESS);
 }
 
 TEST_CASE("NmrRegisterClient with async deregister", "[nmr]")
@@ -381,7 +388,8 @@ TEST_CASE("NmrRegisterClient with async deregister", "[nmr]")
     REQUIRE(_test_provider_binding_context.allocated == false);
     REQUIRE(_test_provider_binding_context.nmr_binding_handle == nullptr);
 
-    REQUIRE(NmrDeregisterProvider(nmr_provider_handle) == STATUS_SUCCESS);
+    REQUIRE(NmrDeregisterProvider(nmr_provider_handle) == STATUS_PENDING);
+    REQUIRE(NmrWaitForProviderDeregisterComplete(nmr_provider_handle) == STATUS_SUCCESS);
 }
 
 TEST_CASE("NmrRegisterProvider with async deregister", "[nmr]")
@@ -417,7 +425,8 @@ TEST_CASE("NmrRegisterProvider with async deregister", "[nmr]")
     REQUIRE(_test_provider_binding_context.allocated == false);
     REQUIRE(_test_provider_binding_context.nmr_binding_handle == nullptr);
 
-    REQUIRE(NmrDeregisterClient(nmr_client_handle) == STATUS_SUCCESS);
+    REQUIRE(NmrDeregisterClient(nmr_client_handle) == STATUS_PENDING);
+    REQUIRE(NmrWaitForClientDeregisterComplete(nmr_client_handle) == STATUS_SUCCESS);
 }
 
 TEST_CASE("concurrent register/deregister smoke", "[nmr][no_fi]")
@@ -476,7 +485,7 @@ TEST_CASE("concurrent register/deregister smoke", "[nmr][no_fi]")
     provider_thread.join();
     client_thread.join();
 
-    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::steady_clock::now() - test_start);
+    const auto elapsed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - test_start);
     std::cout << "smoke test duration: " << elapsed.count() << " ms" << std::endl;
 }


### PR DESCRIPTION
## Summary
Fixes #318 an NMR client deregister can race with an incomplete NMR provider registration.

- Deregistering modules always return `STATUS_PENDING`, matching Windows NMR behavior.
- After attach succeeds, the binding is marked attached. If either module is already deregistering, it is marked `LateBind` and unbound immediately.
- `pending_bind_ops` tracks accepted attach operations that have not completed. Each module also tracks all successfully attached bindings.
- A module cannot be disposed until **both** pending bind operations are complete and its attached-binding list is empty.
- Each binding starts unbind only once. After both detach callbacks complete, it is removed from both module lists and the global binding map.
- add a concurrent register/deregister smoke test that loops provider and client registration/deregistration and prints executed iteration counts

## Testing
- run usersim_tests nmr tests.